### PR TITLE
DataflashParser: fix applying multipliers

### DIFF
--- a/src/tools/dataflashDataExtractor.js
+++ b/src/tools/dataflashDataExtractor.js
@@ -260,15 +260,15 @@ export class DataflashDataExtractor {
                     }
                     trajectory.push(
                         [
-                            gpsData.Lng[i] / 1e7,
-                            gpsData.Lat[i] / 1e7,
+                            gpsData.Lng[i],
+                            gpsData.Lat[i],
                             gpsData.Alt[i] - startAltitude,
                             gpsData.time_boot_ms[i]
                         ]
                     )
                     timeTrajectory[gpsData.time_boot_ms[i]] = [
-                        gpsData.Lng[i] / 1e7,
-                        gpsData.Lat[i] / 1e7,
+                        gpsData.Lng[i],
+                        gpsData.Lat[i],
                         (gpsData.Alt[i] - startAltitude) / 1000,
                         gpsData.time_boot_ms[i]]
                 }
@@ -293,15 +293,15 @@ export class DataflashDataExtractor {
                     }
                     trajectory.push(
                         [
-                            gpsData.Lng[i] * 1e-7,
-                            gpsData.Lat[i] * 1e-7,
+                            gpsData.Lng[i],
+                            gpsData.Lat[i],
                             gpsData.Alt[i] - startAltitude,
                             gpsData.time_boot_ms[i]
                         ]
                     )
                     timeTrajectory[gpsData.time_boot_ms[i]] = [
-                        gpsData.Lng[i] * 1e-7,
-                        gpsData.Lat[i] * 1e-7,
+                        gpsData.Lng[i],
+                        gpsData.Lat[i],
                         (gpsData.Alt[i] - startAltitude) / 1000,
                         gpsData.time_boot_ms[i]]
                 }
@@ -326,15 +326,15 @@ export class DataflashDataExtractor {
                     }
                     trajectory.push(
                         [
-                            gpsData.Lng[i] / 1e7,
-                            gpsData.Lat[i] / 1e7,
+                            gpsData.Lng[i],
+                            gpsData.Lat[i],
                             gpsData.Alt[i] - startAltitude,
                             gpsData.time_boot_ms[i]
                         ]
                     )
                     timeTrajectory[gpsData.time_boot_ms[i]] = [
-                        gpsData.Lng[i] / 1e7,
-                        gpsData.Lat[i] / 1e7,
+                        gpsData.Lng[i],
+                        gpsData.Lat[i],
                         gpsData.Alt[i] - startAltitude,
                         gpsData.time_boot_ms[i]]
                 }

--- a/src/tools/parsers/dataflashParser.js
+++ b/src/tools/parsers/dataflashParser.js
@@ -563,13 +563,12 @@ export class DataflashParser {
     fixDataOnce (name) {
         if (['GPS', 'ATT', 'AHR2', 'MODE'].indexOf(name) === -1) {
             if (this.messageTypes.hasOwnProperty(name)) {
-                let fields = this.messages[name][0].fieldnames
+                let fields = this.messageTypes[name].complexFields
                 if (this.messageTypes[name].hasOwnProperty('multipliers')) {
-                    for (let message in this.messages[name]) {
-                        for (let i = 1; i < fields.length; i++) {
-                            let fieldname = fields[i]
-                            if (!isNaN(this.messageTypes[name].multipliers[i])) {
-                                this.messages[name][message][fieldname] *= this.messageTypes[name].multipliers[i]
+                    for (let [fieldname, field] of Object.entries(fields)) {
+                        if (!isNaN(field.multiplier) && field.multiplier !== 0) {
+                            for (let i = 0; i < this.messages[name].length; i++) {
+                                this.messages[name][i][fieldname] *= field.multiplier
                             }
                         }
                     }
@@ -668,7 +667,7 @@ export class DataflashParser {
                             messageTypes[msg.Name + '[' + instance + ']'] = {
                                 expressions: fields,
                                 units: msg.units,
-                                multipiers: msg.multipliers,
+                                multipliers: msg.multipliers,
                                 complexFields: complexFields
                             }
                         }
@@ -676,7 +675,7 @@ export class DataflashParser {
                         messageTypes[msg.Name] = {
                             expressions: fields,
                             units: msg.units,
-                            multipiers: msg.multipliers,
+                            multipliers: msg.multipliers,
                             complexFields: complexFields
                         }
                     }

--- a/src/tools/parsers/mavlinkParser.js
+++ b/src/tools/parsers/mavlinkParser.js
@@ -296,7 +296,7 @@ export class MavlinkParser {
             messageTypes[msg] = {
                 expressions: fields,
                 units: null,
-                multipiers: null,
+                multipliers: null,
                 complexFields: complexFields
             }
         }


### PR DESCRIPTION
Multipliers were lost when refactoring the messages structures a long time ago... this fixes that.
A side effect is that currTot will now show in A.s instead of mAh...