### PR TITLE
dataflashparser.js: move AHR2 parsing to before ATT

### DIFF
--- a/src/tools/parsers/dataflashParser.js
+++ b/src/tools/parsers/dataflashParser.js
@@ -697,6 +697,7 @@ export class DataflashParser {
         this.parseAtOffset('CMD')
         this.parseAtOffset('MSG')
         this.parseAtOffset('MODE')
+        this.parseAtOffset('AHR2')
         this.parseAtOffset('ATT')
         this.parseAtOffset('GPS')
         this.parseAtOffset('POS')
@@ -708,7 +709,6 @@ export class DataflashParser {
         this.parseAtOffset('MSG')
         this.parseAtOffset('STAT')
         this.parseAtOffset('EV')
-        this.parseAtOffset('AHR2')
         let metadata = {
             startTime: this.extractStartTime()
         }


### PR DESCRIPTION
This makes AHR2 the preferential attitude source