### PR TITLE
Cesium: only tie start position to ground height

### DIFF
--- a/src/components/CesiumViewer.vue
+++ b/src/components/CesiumViewer.vue
@@ -243,9 +243,7 @@ export default {
                     * Second step of setup, happens after the height of the starting point has been returned by Cesium
                     * */
                     this.heightOffset = 0
-                    for (let pos of updatedPositions) {
-                        this.heightOffset = Math.max(this.heightOffset, pos.height)
-                    }
+                    this.heightOffset = Math.max(this.heightOffset, updatedPositions[0].height)
                     this.processTrajectory(this.state.currentTrajectory)
                     this.addModel()
                     this.updateAndPlotTrajectory()


### PR DESCRIPTION
Previous behavior was checking all points and making sure nothing goes underground.
That is no longer necessary as we can now make the globe transparent.

Fix #266