### PR TITLE
Allow downloading trimmed .tlog files

### DIFF
--- a/mavlink_common_v1.0/mavlink.js
+++ b/mavlink_common_v1.0/mavlink.js
@@ -18700,6 +18700,34 @@ MAVLink.prototype.parseType = function (type) {
     return messages
 }
 
+MAVLink.prototype.trimFile = function (start, end) {
+    let startOffset = null
+    let endOffset = null
+    let startTimestamp = null
+    for (let offsets of this.bufmap[mavlink.nameMap['HEARTBEAT']]) {
+        let m = this.decode(this.buf.slice(offsets[0], offsets[1]))
+        // The 8 bytes preceding the mavlink message are actually a very useful timestamp saved by the GCS!
+        let slice = this.buf.slice(offsets[0]-8, offsets[0])
+        let timestamp = new Uint64BE(slice)/1000 - this.startTime
+        if (timestamp > start && startOffset === null)
+        {
+            startOffset = offsets[0]
+        }
+        if (timestamp > end && endOffset === null) {
+            endOffset = offsets[0]
+            break
+        }
+    }
+    if (endOffset === null) {
+        const bufmap = this.bufmap[mavlink.nameMap['HEARTBEAT']]
+        endOffset = bufmap[bufmap.length-1][1]
+    }
+    const blob = new Blob([this.buf.slice(startOffset, endOffset)], {type: "application/octet-stream"});
+    const url = URL.creat
+    eObjectURL(blob);
+    return url
+}
+
 // Expose this code as a module
 module.exports.mavlink = mavlink
 module.exports.MAVLink = MAVLink

--- a/src/components/SideBarFileManager.vue
+++ b/src/components/SideBarFileManager.vue
@@ -57,11 +57,15 @@ export default {
     },
     created () {
         this.$eventHub.$on('loadType', this.loadType)
+        this.$eventHub.$on('trimFile', this.trimFile)
     },
     beforeDestroy () {
         this.$eventHub.$off('open-sample')
     },
     methods: {
+        trimFile () {
+            worker.postMessage({action: 'trimFile', time: this.state.timeRange})
+        },
         onLoadSample (file) {
             let url
             if (file === 'sample') {
@@ -186,6 +190,16 @@ export default {
             document.execCommand('copy')
             document.body.removeChild(el)
             this.shared = true
+        },
+        downloadFileFromURL (url) {
+            var a = document.createElement('a')
+            document.body.appendChild(a)
+            a.style = 'display: none'
+            a.href = url
+            a.download = this.state.file + '-trimmed.' + this.state.logType
+            a.click()
+            document.body.removeChild(a)
+            window.URL.revokeObjectURL(url)
         }
     },
     mounted () {
@@ -202,6 +216,8 @@ export default {
             } else if (event.data.hasOwnProperty('messageType')) {
                 this.state.messages[event.data.messageType] = event.data.messageList
                 this.$eventHub.$emit('messages')
+            } else if (event.data.hasOwnProperty('url')) {
+                this.downloadFileFromURL(event.data.url)
             }
         }
         if (this.$route.params.hasOwnProperty('id')) {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -124,6 +124,13 @@
                             <a class="check-font download-text" v-bind:href="downloadURL"
                                v-bind:download="fileName" ref="downloadFile"> Download </a>
                         </label>
+                        <label v-if="state.logType==='tlog'" v-on:click="downloadTrimmed">
+                            <i
+                            class="fa fa-download circle"
+                            title="Download a log with starting and end time matching the current views">
+                            </i>
+                            <a class="check-font"> Trimmed log </a>
+                        </label>
                     </div>
                 </div>
             </b-collapse>
@@ -192,6 +199,9 @@ export default {
 
         download () {
             this.$refs.downloadFile.click()
+        },
+        downloadTrimmed () {
+            this.$eventHub.$emit('trimFile')
         }
     },
     created () {

--- a/src/tools/parsers/mavlinkParser.js
+++ b/src/tools/parsers/mavlinkParser.js
@@ -236,6 +236,12 @@ export class MavlinkParser {
         return {types: messageTypes, messages: instance.messages}
     }
 
+    trimFile (time) {
+        const start = time[0]
+        const end = time[1]
+        console.log('triming', start, end)
+        self.postMessage({url: this.mavlinkParser.trimFile(start, end)})
+    }
     loadType (type) {
         this.mavlinkParser.parseType(type)
         console.log('done')

--- a/src/tools/parsers/parser.worker.js
+++ b/src/tools/parsers/parser.worker.js
@@ -18,5 +18,7 @@ self.addEventListener('message', function (event) {
         parser.processData(data)
     } else if (event.data.action === 'loadType') {
         parser.loadType(event.data.type.split('[')[0])
+    } else if (event.data.action === 'trimFile') {
+        parser.trimFile(event.data.time)
     }
 })


### PR DESCRIPTION
This allows the user to export the current time-span of the log as a standalone log.
currently only implemented for .tlog files

helps #244 