### PR TITLE
Plotly: use replaceAll when plotting expressions

### DIFF
--- a/src/components/Plotly.vue
+++ b/src/components/Plotly.vue
@@ -555,7 +555,7 @@ export default {
                 if (isNaN(field)) {
                     break
                 }
-                expression = expression.replace(fields[field], 'a[' + field + ']')
+                expression = expression.replaceAll(fields[field], 'a[' + field + ']')
             }
             let f
             try {


### PR DESCRIPTION
fix #262 