### PR TITLE
components: Mode 1 and 2 can be specified on the joystick display

### DIFF
--- a/src/components/CesiumViewer.vue
+++ b/src/components/CesiumViewer.vue
@@ -901,6 +901,9 @@ export default {
         },
         trajectorySource () {
             return this.state.trajectorySource
+        },
+        radioMode () {
+            return this.state.radioMode
         }
     },
     watch: {

--- a/src/components/Globals.js
+++ b/src/components/Globals.js
@@ -49,6 +49,7 @@ export var store = {
         '#d62728',
         '#9467BD',
         '#8C564B'],
+    radioMode: '2',
     /* global _COMMIT_ */
     commit: _COMMIT_.slice(0, 6),
     /* global _BUILDDATE_ */

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -162,6 +162,13 @@
                         </li>
                         </ul>
                     </div>
+                    <div>
+                        <label><i class="fas fa-gamepad"></i> Radio Mode</label>
+                        <select class="cesium-button" v-model="state.radioMode">
+                            <option value="1">1</option>
+                            <option value="2">2</option>
+                        </select>
+                    </div>
                 </div>
             </b-collapse>
         </div>

--- a/src/components/widgets/TxInputs.vue
+++ b/src/components/widgets/TxInputs.vue
@@ -151,13 +151,19 @@ export default {
             return -29 + 0.01 * this.channels[this.yawMap] * this.width / 2
         },
         leftStickTop () {
-            return 0.02 * (100 - this.channels[this.throttleMap]) * this.circleHeight - 22
+            if (this.state.radioMode === '2') {
+                return 0.02 * (100 - this.channels[this.throttleMap]) * this.circleHeight - 22
+            }
+            return 0.02 * (100 - this.channels[this.pitchMap]) * this.circleHeight - 22
         },
         rightStickLeft () {
             return -29 + (0.01 * this.channels[this.rollMap]) * (this.width / 2)
         },
         rightStickTop () {
-            return 0.02 * (100 - this.channels[this.pitchMap]) * this.circleHeight - 22
+            if (this.state.radioMode === '2') {
+                return 0.02 * (100 - this.channels[this.pitchMap]) * this.circleHeight - 22
+            }
+            return 0.02 * (100 - this.channels[this.throttleMap]) * this.circleHeight - 22
         },
         circleHeight () {
             return this.height * (69 / 150)


### PR DESCRIPTION
Many operators in Japan operate their drones in mode 1 of the radio.
The joystick display in UAVLogViewer is in Mode 2.
I have added a setting item to allow selection of mode 1 or 2.


AFTER

MODE 1
![Screenshot from 2022-05-22 13-30-57](https://user-images.githubusercontent.com/646194/169680548-5fbb661c-b1c8-4dc3-8c95-29c3a175f29a.png)


MODE2
![Screenshot from 2022-05-22 13-31-11](https://user-images.githubusercontent.com/646194/169680563-88fb6934-7af2-4145-8e69-992ce9fbf0f9.png)