### PR TITLE
Allow parsing a file from window.postMessage()

### DIFF
--- a/src/components/SideBarFileManager.vue
+++ b/src/components/SideBarFileManager.vue
@@ -209,6 +209,15 @@ export default {
         }
     },
     mounted () {
+        window.addEventListener('message', (event) => {
+            if (event.data.type === 'arrayBuffer') {
+                worker.postMessage({
+                    action: 'parse',
+                    file: event.data.data,
+                    isTlog: false
+                })
+            }
+        })
         worker.onmessage = (event) => {
             if (event.data.percentage) {
                 this.state.processPercentage = event.data.percentage


### PR DESCRIPTION
the other side should do something like this:
```
!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>File Loader</title>
</head>
<body>
  <input type="file" id="fileInput">

  <script>
    const fileInput = document.getElementById('fileInput')

    fileInput.addEventListener('change', function(event) {
      const file = event.target.files[0]
      if (file) {
        const reader = new FileReader()

        reader.onload = function(e) {
          const arrayBuffer = e.target.result

          // Open the new page and keep a reference to it
          const newWindow = window.open('http://localhost:8080')

          // Wait a bit to ensure the new page is fully loaded
          setTimeout(() => {
            // Send the ArrayBuffer to the new window using postMessage
            newWindow.postMessage({ type: 'arrayBuffer', data: arrayBuffer }, 'http://localhost:8080')
          }, 2000)
        }

        reader.readAsArrayBuffer(file)
      }
    })
  </script>
</body>
</html>
```

This passes the whole ArrayBuffer through the message, which is not ideal, but it seems to work well enough.