### PR TITLE
fixed docker reference to be lower case

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm test
 run the prebuilt docker image:
 
 ``` bash
-docker run -p 8080:8080 -d ghcr.io/ArduPilot/UAVLogViewer:latest
+docker run -p 8080:8080 -d ghcr.io/ardupilot/uavlogviewer:latest
 
 ```
 


### PR DESCRIPTION
As noticed here https://github.com/ArduPilot/UAVLogViewer/pull/431#issuecomment-2887716161, the docker reference I made in the readme included upper case letters which wrong.

Also the workflow will only upload a docker image to ghcr if you create a release ( a tag with format v.xx).
So it would be good to trigger this once as otherwise there will be no latest image to download.