### PR TITLE
Use self-hosted quantized-mesh terrain and keyless imagery

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -23,6 +23,11 @@ module.exports = {
         target:"http://localhost:8001/uploaded",
         secure:"false"
       },
+      "/quantized/*":{
+        target:"https://plot.ardupilot.org",
+        changeOrigin:true,
+        secure:true
+      },
     },
 
     // Various Dev Server settings

--- a/scripts/terrain/README.md
+++ b/scripts/terrain/README.md
@@ -1,0 +1,99 @@
+# SRTM → Cesium quantized-mesh tiler
+
+Builds a Cesium `quantized-mesh-1.0` terrain tileset (`layer.json` + `{z}/{x}/{y}.terrain`)
+from ArduPilot's existing SRTM `.hgt.zip` cells, so the log viewer can serve its own 3D
+terrain instead of paying for Cesium ion. This is the server-side ("Path B") half of the
+ion-removal work; the client change is `CesiumTerrainProvider.fromUrl('/quantized/')` in
+`CesiumViewer.vue`.
+
+Reads cells via GDAL `/vsizip/` (no unzip). Output is EPSG:4326 / TMS with oct-encoded
+vertex normals (for lighting) and per-level availability in `layer.json` (so
+`sampleTerrainMostDetailed` keeps working). Parallel and **resumable** — existing `.terrain`
+files are skipped unless `--force`, so a long run can be re-run after an interruption.
+
+## Mesher
+
+Each tile is meshed on a **regular `--grid` (default 65×65) lattice** whose samples land
+exactly on the tile's corners and edges. Because neighbouring tiles then share identical
+edge vertices, there are **no seam cracks / "walls"** (the failure mode of an adaptive
+per-tile TIN). The window is read one half-step oversized and uses rasterio `boundless`
+reads only where the tile pokes past the DEM extent, which keeps interior tiles fast and
+edge-aligned. `pydelatin` (`--max-error`) is still imported for an experimental adaptive
+path but is **not** the default.
+
+## Setup (Ubuntu 24.04 / Python 3.12)
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt   # rasterio wheel bundles GDAL; no apt needed
+```
+
+## Build (two steps for a whole-world / large run)
+
+Low zooms read many cells at once, so for anything large first bake a **coarse global DEM**
+(1 arcmin GeoTIFF, tiled + overviews) and feed it in for the low levels — `srtm_to_qmesh.py`
+then never does huge multi-cell full-res reads:
+
+```bash
+. .venv/bin/activate
+
+# 1. coarse global DEM (once), used as the source for z <= --coarse-max-zoom
+./build_coarse.py --srtm-dir /path/to/SRTM3 --out /path/to/quantized_coarse.tif --jobs 4
+
+# 2a. small test area — a single SRTM3 cell, no coarse DEM needed
+./srtm_to_qmesh.py --cell S36E149 --srtm-dir /path/to/SRTM3 --out /path/to/quantized
+
+# 2b. region by radius (SRTM1, higher detail)
+./srtm_to_qmesh.py --center -35.28 149.13 --radius-km 40 --srtm-res 1 \
+    --srtm-dir /path/to/SRTM1 --out /path/to/quantized --jobs 4
+
+# 2c. whole world (SRTM1 to z11; coarse DEM supplies z0..z8). Long; re-run to resume:
+./srtm_to_qmesh.py --srtm-res 1 --srtm-dir /path/to/SRTM1 --out /path/to/quantized \
+    --max-zoom 11 --jobs 4 \
+    --coarse-dem /path/to/quantized_coarse.tif --coarse-max-zoom 8
+```
+
+Area selection (mutually exclusive): `--cell S36E149 [...]`, `--bbox W S E N`, or
+`--center LAT LON --radius-km R`. With none, the whole local SRTM cell set is used
+(oceans skipped). Other flags: `--srtm-res {1,3}` (default 3), `--max-zoom`
+(default 13 for res 1, 11 for res 3), `--min-zoom` (>0 merges into existing availability
+for incremental upgrades), `--grid` (default 65), `--max-error` (adaptive path only),
+`--force` (rebuild existing tiles), `--jobs` (default = CPU count).
+
+## Serving (nginx)
+
+```nginx
+location /quantized/ {
+    root /mnt/terrain_data/data;     # serves /mnt/terrain_data/data/quantized/...
+    autoindex on;
+    gzip off;                        # tiles are already gzipped
+    add_header Access-Control-Allow-Origin *;
+    location ~ \.terrain$ {
+        root /mnt/terrain_data/data;
+        add_header Content-Encoding gzip;
+        default_type application/octet-stream;
+        add_header Access-Control-Allow-Origin *;
+    }
+}
+```
+
+Client: `CesiumTerrainProvider.fromUrl('/quantized/')` (served under the app origin, or
+reverse-proxied there to avoid cross-subdomain CORS). `.terrain` files and `layer.json` are
+written gzip-compressed.
+
+## Notes / caveats
+
+- **Disk**: SRTM3 global ≈ 20–40 GB. SRTM1 to z11 global is far larger (hundreds of GB) —
+  size the target before a world run.
+- **Heights** are raw SRTM (orthometric / EGM96), not ellipsoidal — a tens-of-metres global
+  offset vs strict WGS84. Fine for visualisation; revisit for precise AMSL overlay.
+- **Availability vs reality**: `layer.json` must only advertise levels/rects that actually
+  exist on disk — over-claiming makes Cesium fetch missing/old tiles (and is how stale
+  high-zoom tiles can surface as walls during a partial rebuild). Cap availability to the
+  finished levels while a long rebuild is in flight.
+- Coverage is SRTM's 56°S–60°N; outside that there are no cells (client falls back to the
+  ellipsoid).
+- `/vsizip` re-reads the zip per tile; pre-unzipping cells to `.hgt` speeds up an I/O-bound
+  world build.
+```

--- a/scripts/terrain/build_coarse.py
+++ b/scripts/terrain/build_coarse.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Build a coarse global DEM GeoTIFF from SRTM3, used as the source for low-zoom
+quantized-mesh tiles (so srtm_to_qmesh.py never reads huge multi-cell windows from
+full-res SRTM at low zoom). Parallel per-cell (4 cores) with progress; output is
+tiled + has internal overviews for fast windowed reads.
+
+  ./build_coarse.py --srtm-dir /mnt/terrain_data/data/SRTM3 \
+      --out /mnt/terrain_data/data/quantized_coarse.tif --jobs 4
+"""
+import argparse
+import os
+import time
+from concurrent.futures import ProcessPoolExecutor
+
+import numpy as np
+import rasterio
+from rasterio import Affine
+from rasterio.enums import Resampling
+
+from srtm_to_qmesh import find_cells, cell_name
+
+_PPD = 60  # output px per degree (60 = 1 arcmin)
+
+
+def _read_cell(c):
+    lat0, lon0, path = c
+    inner = cell_name(lat0, lon0) + '.hgt'
+    src = ('/vsizip/%s/%s' % (path, inner)) if path.endswith('.zip') else path
+    try:
+        with rasterio.open(src) as ds:
+            a = ds.read(1, out_shape=(_PPD, _PPD), resampling=Resampling.average)
+    except Exception:
+        return (lat0, lon0, None)
+    a = a.astype(np.int16)
+    a[a < -1000] = 0
+    return (lat0, lon0, a)
+
+
+def main():
+    global _PPD
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--srtm-dir', required=True)
+    ap.add_argument('--out', required=True, help='output GeoTIFF')
+    ap.add_argument('--ppd', type=int, default=60, help='px per degree (60 = 1 arcmin)')
+    ap.add_argument('--jobs', type=int, default=os.cpu_count())
+    args = ap.parse_args()
+    _PPD = args.ppd
+
+    cells = list(find_cells(args.srtm_dir).values())
+    lon0s = [c[1] for c in cells]
+    lat0s = [c[0] for c in cells]
+    min_lon, max_lon = min(lon0s), max(lon0s)
+    min_lat, max_lat = min(lat0s), max(lat0s)
+    W = (max_lon + 1 - min_lon) * args.ppd
+    H = (max_lat + 1 - min_lat) * args.ppd
+    print('cells=%d  grid=%dx%d (ppd=%d)  jobs=%d' % (len(cells), W, H, args.ppd, args.jobs),
+          flush=True)
+
+    grid = np.zeros((H, W), np.int16)
+    t0 = time.time()
+    done = 0
+    with ProcessPoolExecutor(max_workers=args.jobs) as ex:
+        for (lat0, lon0, a) in ex.map(_read_cell, cells, chunksize=32):
+            done += 1
+            if a is not None:
+                col = (lon0 - min_lon) * args.ppd
+                row = (max_lat - lat0) * args.ppd
+                grid[row:row + args.ppd, col:col + args.ppd] = a
+            if done % 2000 == 0 or done == len(cells):
+                print('  %d/%d cells  %.0fs' % (done, len(cells), time.time() - t0), flush=True)
+
+    transform = Affine(1.0 / args.ppd, 0, min_lon, 0, -1.0 / args.ppd, max_lat + 1)
+    profile = dict(driver='GTiff', dtype='int16', count=1, width=W, height=H,
+                   crs='EPSG:4326', transform=transform, nodata=-32768,
+                   tiled=True, blockxsize=512, blockysize=512, compress='deflate')
+    print('writing %s' % args.out, flush=True)
+    with rasterio.open(args.out, 'w', **profile) as dst:
+        dst.write(grid, 1)
+        dst.build_overviews([2, 4, 8, 16, 32], Resampling.average)
+    print('done in %.0fs' % (time.time() - t0), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/terrain/requirements.txt
+++ b/scripts/terrain/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+rasterio
+pydelatin
+quantized-mesh-encoder

--- a/scripts/terrain/srtm_to_qmesh.py
+++ b/scripts/terrain/srtm_to_qmesh.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Convert ArduPilot SRTM .hgt(.zip) cells into a Cesium quantized-mesh tileset.
+
+Output: <out>/layer.json + <out>/{z}/{x}/{y}.terrain (gzipped), EPSG:4326 / TMS,
+with octvertexnormals (lighting) and per-level availability (so sampleTerrainMostDetailed
+works). Reads cells through GDAL /vsizip (no unzip needed). Parallel and resumable
+(existing tiles are skipped).
+
+Examples:
+  # Canberra test (single cell), SRTM3:
+  ./srtm_to_qmesh.py --cell S36E149 --srtm-dir /mnt/terrain_data/data/SRTM3 \
+      --out /mnt/terrain_data/data/quantized
+  # A bbox at SRTM1:
+  ./srtm_to_qmesh.py --bbox 149 -36 150 -35 --srtm-dir /mnt/terrain_data/data/SRTM1 \
+      --out /mnt/terrain_data/data/quantized --jobs 4
+  # Whole world from SRTM3 (cell-driven, skips oceans):
+  ./srtm_to_qmesh.py --srtm-dir /mnt/terrain_data/data/SRTM3 \
+      --out /mnt/terrain_data/data/quantized --jobs 4
+"""
+import argparse
+import glob
+import gzip
+import io
+import json
+import os
+import re
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor
+
+import numpy as np
+import rasterio
+from rasterio.enums import Resampling
+from rasterio.windows import from_bounds
+from pydelatin import Delatin
+from quantized_mesh_encoder import encode, VertexNormalsExtension
+
+CELL_RE = re.compile(r'^([NS])(\d{2})([EW])(\d{3})$')
+
+# Default max zoom by source resolution (tile ~ native block at that level).
+DEFAULT_MAXZOOM = {1: 13, 3: 11}
+
+
+def parse_cell(name):
+    """'S36E149' -> (lat0, lon0) of the SW corner."""
+    m = CELL_RE.match(name)
+    if not m:
+        return None
+    ns, la, ew, lo = m.groups()
+    lat = int(la) * (1 if ns == 'N' else -1)
+    lon = int(lo) * (1 if ew == 'E' else -1)
+    return lat, lon
+
+
+def cell_name(lat0, lon0):
+    return '%s%02d%s%03d' % ('N' if lat0 >= 0 else 'S', abs(lat0),
+                             'E' if lon0 >= 0 else 'W', abs(lon0))
+
+
+def tile_size_deg(z):
+    return 180.0 / (1 << z)
+
+
+def tile_bounds(z, x, y):
+    """Geographic rect of TMS tile (y from south). Returns (west, south, east, north)."""
+    s = tile_size_deg(z)
+    west = -180.0 + x * s
+    south = -90.0 + y * s
+    return west, south, west + s, south + s
+
+
+def tile_range_for_bbox(z, w, s, e, n):
+    """Inclusive (x0, x1, y0, y1) tile range covering a geographic bbox at zoom z."""
+    sz = tile_size_deg(z)
+    nx = 2 << z  # numberOfXTiles = 2 * 2^z
+    ny = 1 << z
+    x0 = max(0, int((w + 180.0) / sz))
+    x1 = min(nx - 1, int((e + 180.0 - 1e-9) / sz))
+    y0 = max(0, int((s + 90.0) / sz))
+    y1 = min(ny - 1, int((n + 90.0 - 1e-9) / sz))
+    return x0, x1, y0, y1
+
+
+# ---------------------------------------------------------------- source / VRT
+
+def find_cells(srtm_dir):
+    """name -> (lat0, lon0, zip_path) for every NxxExxx.hgt.zip under srtm_dir."""
+    out = {}
+    for p in glob.iglob(os.path.join(srtm_dir, '**', '*.hgt.zip'), recursive=True):
+        name = os.path.basename(p)[:-len('.hgt.zip')]
+        c = parse_cell(name)
+        if c:
+            out[name] = (c[0], c[1], p)
+    return out
+
+
+def build_vrt(cells, vrt_path):
+    """Write a GDAL VRT mosaicking the given cells (list of (lat0, lon0, zip_path))."""
+    # Probe the first cell for size / dtype (all SRTM cells share a grid phase).
+    lat0, lon0, zp = cells[0]
+    inner = cell_name(lat0, lon0) + '.hgt'
+    with rasterio.open('/vsizip/%s/%s' % (zp, inner)) as ds:
+        size = ds.width  # 3601 (SRTM1) or 1201 (SRTM3)
+    ppd = size - 1      # posts per degree (3600 / 1200)
+    res = 1.0 / ppd
+    lon0s = [c[1] for c in cells]
+    lat0s = [c[0] for c in cells]
+    min_lon, max_lon = min(lon0s), max(lon0s)
+    min_lat, max_lat = min(lat0s), max(lat0s)
+    max_north = max_lat + 1
+    rx = (max_lon + 1 - min_lon) * ppd + 1
+    ry = (max_north - min_lat) * ppd + 1
+    gleft = min_lon - 0.5 * res
+    gtop = max_north + 0.5 * res
+    srcs = []
+    for (la, lo, zp) in cells:
+        inner = cell_name(la, lo) + '.hgt'
+        xoff = round((lo - min_lon) * ppd)
+        yoff = round((max_north - (la + 1)) * ppd)
+        srcs.append(
+            '<SimpleSource><SourceFilename relativeToVRT="0">/vsizip/%s/%s'
+            '</SourceFilename><SourceBand>1</SourceBand>'
+            '<SrcRect xOff="0" yOff="0" xSize="%d" ySize="%d"/>'
+            '<DstRect xOff="%d" yOff="%d" xSize="%d" ySize="%d"/></SimpleSource>'
+            % (zp, inner, size, size, xoff, yoff, size, size))
+    xml = (
+        '<VRTDataset rasterXSize="%d" rasterYSize="%d">'
+        '<SRS>EPSG:4326</SRS>'
+        '<GeoTransform>%.10f, %.12f, 0, %.10f, 0, %.12f</GeoTransform>'
+        '<VRTRasterBand dataType="Int16" band="1"><NoDataValue>-32768</NoDataValue>'
+        '%s</VRTRasterBand></VRTDataset>'
+        % (rx, ry, gleft, res, gtop, -res, ''.join(srcs)))
+    with open(vrt_path, 'w') as f:
+        f.write(xml)
+    return ppd
+
+
+# ---------------------------------------------------------------- tile render
+
+# Per-worker globals (set in init so the VRT is opened once per process).
+_VRT = None
+_DS = None
+_DS_COARSE = None
+_COARSE_MAXZ = -1
+_OUT = None
+_MAX_ERROR = None
+_TILE_PX = None
+_FORCE = False
+_GRID = 0
+_GRID_IDX = None
+
+
+def _grid_indices(g):
+    """Triangle indices for a regular g x g vertex grid (row-major)."""
+    r, c = np.mgrid[0:g - 1, 0:g - 1]
+    v00 = (r * g + c).ravel()
+    tri1 = np.stack([v00, v00 + g, v00 + g + 1], axis=1)
+    tri2 = np.stack([v00, v00 + g + 1, v00 + 1], axis=1)
+    return np.concatenate([tri1, tri2]).astype(np.uint32)
+
+
+def _init_worker(vrt_path, out_dir, max_error, tile_px, force, coarse_dem,
+                 coarse_maxz, grid):
+    global _VRT, _DS, _DS_COARSE, _COARSE_MAXZ, _OUT, _MAX_ERROR, _TILE_PX, _FORCE
+    global _GRID, _GRID_IDX
+    _VRT, _OUT, _MAX_ERROR, _TILE_PX, _FORCE = \
+        vrt_path, out_dir, max_error, tile_px, force
+    _DS = rasterio.open(vrt_path)
+    _COARSE_MAXZ = coarse_maxz
+    _DS_COARSE = rasterio.open(coarse_dem) if coarse_dem else None
+    _GRID = grid
+    _GRID_IDX = _grid_indices(grid) if grid > 0 else None
+
+
+def render_tile(zxy):
+    z, x, y = zxy
+    out_file = os.path.join(_OUT, str(z), str(x), '%d.terrain' % y)
+    if not _FORCE and os.path.exists(out_file):
+        return 'skip'
+    # Low zoom reads the coarse global DEM (cheap, has overviews); high zoom reads
+    # full-res SRTM (each tile then covers only ~1 cell, so the window is bounded).
+    ds = _DS_COARSE if (_DS_COARSE is not None and z <= _COARSE_MAXZ) else _DS
+    west, south, east, north = tile_bounds(z, x, y)
+
+    if _GRID > 0:
+        # Sample a regular g x g grid whose pixel centres land exactly on the tile
+        # corners/edges (read window expanded half a step), so neighbouring tiles
+        # share identical edge vertices -> no cracks, no exposed skirts.
+        g = _GRID
+        sx = (east - west) / (g - 1)
+        sy = (north - south) / (g - 1)
+        ew, es, ee, en = west - sx / 2, south - sy / 2, east + sx / 2, north + sy / 2
+        # Only the (slow) boundless read path is needed when the window pokes past the
+        # data extent (coverage edges); interior tiles read directly (~12x faster).
+        db = ds.bounds
+        inside = ew >= db.left and es >= db.bottom and ee <= db.right and en <= db.top
+        arr = ds.read(1, window=from_bounds(ew, es, ee, en, ds.transform),
+                      out_shape=(g, g), resampling=Resampling.bilinear,
+                      boundless=not inside, fill_value=0).astype(np.float32)
+        arr[arr < -1000.0] = 0.0
+        rr, cc = np.mgrid[0:g, 0:g]
+        lon = west + cc.ravel() * sx
+        lat = north - rr.ravel() * sy
+        pos = np.column_stack([lon, lat, arr.ravel()]).astype(np.float32)
+        idx = _GRID_IDX
+    else:
+        # Adaptive Delatin mesh, with the read clamped to the data extent so low-zoom
+        # tiles don't trigger a giant boundless read of the whole mosaic.
+        db = ds.bounds
+        iw, ie = max(west, db.left), min(east, db.right)
+        isb, itn = max(south, db.bottom), min(north, db.top)
+        if ie <= iw or itn <= isb:
+            return 'empty'  # tile doesn't overlap any source data
+        resx, resy = ds.res
+        ow = max(2, min(int(round((east - west) / resx)) + 1, _TILE_PX))
+        oh = max(2, min(int(round((north - south) / resy)) + 1, _TILE_PX))
+        arr = np.zeros((oh, ow), np.float32)
+        cx0 = max(0, int(np.floor((iw - west) / (east - west) * (ow - 1))))
+        cx1 = min(ow - 1, int(np.ceil((ie - west) / (east - west) * (ow - 1))))
+        ry0 = max(0, int(np.floor((north - itn) / (north - south) * (oh - 1))))
+        ry1 = min(oh - 1, int(np.ceil((north - isb) / (north - south) * (oh - 1))))
+        sw, sh = cx1 - cx0 + 1, ry1 - ry0 + 1
+        if sw < 2 or sh < 2:
+            return 'empty'
+        bw = west + cx0 / (ow - 1) * (east - west)
+        be = west + cx1 / (ow - 1) * (east - west)
+        bn = north - ry0 / (oh - 1) * (north - south)
+        bs = north - ry1 / (oh - 1) * (north - south)
+        sub = ds.read(1, window=from_bounds(bw, bs, be, bn, ds.transform),
+                      out_shape=(sh, sw), resampling=Resampling.bilinear,
+                      boundless=True, fill_value=0).astype(np.float32)
+        sub[sub < -1000.0] = 0.0
+        arr[ry0:ry0 + sh, cx0:cx0 + sw] = sub
+        tin = Delatin(arr, max_error=_MAX_ERROR)
+        verts, tris = tin.vertices, tin.triangles
+        if len(tris) == 0:
+            return 'empty'
+        W, H = ow, oh
+        lon = west + verts[:, 0] / (W - 1) * (east - west)
+        lat = north - verts[:, 1] / (H - 1) * (north - south)
+        pos = np.column_stack([lon, lat, verts[:, 2]]).astype(np.float32)
+        idx = tris.astype(np.uint32)
+    ext = VertexNormalsExtension(indices=idx, positions=pos)
+    buf = io.BytesIO()
+    encode(buf, pos, idx, bounds=(west, south, east, north), extensions=[ext])
+    os.makedirs(os.path.dirname(out_file), exist_ok=True)
+    tmp = out_file + '.tmp%d' % os.getpid()
+    with open(tmp, 'wb') as f:
+        f.write(gzip.compress(buf.getvalue(), 6))
+    os.replace(tmp, out_file)
+    return 'ok'
+
+
+# ---------------------------------------------------------------- work list
+
+def build_worklist(cells, minzoom, maxzoom, clip=None):
+    """Cell-driven tile set: only tiles intersecting an existing cell (oceans skipped).
+    Levels minzoom..maxzoom. If clip=[W,S,E,N], tiles are restricted to that bbox."""
+    tiles = set()
+    per_level = {}
+    for (la, lo, _zp) in cells:
+        w, s, e, n = lo, la, lo + 1, la + 1
+        if clip:
+            w, s = max(w, clip[0]), max(s, clip[1])
+            e, n = min(e, clip[2]), min(n, clip[3])
+            if e <= w or n <= s:
+                continue
+        for z in range(minzoom, maxzoom + 1):
+            x0, x1, y0, y1 = tile_range_for_bbox(z, w, s, e, n)
+            lvl = per_level.setdefault(z, set())
+            for x in range(x0, x1 + 1):
+                for yy in range(y0, y1 + 1):
+                    tiles.add((z, x, yy))
+                    lvl.add((x, yy))
+    return tiles, per_level
+
+
+def availability(per_level, maxzoom):
+    """Row-merge each level's (x,y) tiles into rectangles for layer.json."""
+    out = []
+    for z in range(maxzoom + 1):
+        rects = []
+        rows = {}
+        for (x, y) in per_level.get(z, ()):
+            rows.setdefault(y, []).append(x)
+        for y in sorted(rows):
+            xs = sorted(rows[y])
+            run_start = prev = xs[0]
+            for x in xs[1:] + [None]:
+                if x is None or x != prev + 1:
+                    rects.append({'startX': run_start, 'startY': y,
+                                  'endX': prev, 'endY': y})
+                    run_start = x
+                prev = x if x is not None else prev
+        out.append(rects)
+    return out
+
+
+def write_layer_json(out_dir, maxzoom, per_level, min_zoom):
+    """Write layer.json. For an upgrade run (min_zoom > 0) availability is merged into
+    the existing tileset so the base levels are kept (Cesium ORs the rectangle lists).
+    A full run (min_zoom == 0) writes fresh availability so it never advertises stale
+    tiles from a previous build."""
+    path = os.path.join(out_dir, 'layer.json')
+    new_avail = availability(per_level, maxzoom)
+    old_avail, old_max = [], -1
+    if min_zoom > 0 and os.path.exists(path):
+        try:
+            old = json.load(open(path))
+            old_avail = old.get('available', [])
+            old_max = old.get('maxzoom', len(old_avail) - 1)
+        except Exception:
+            pass
+    final_max = max(maxzoom, old_max)
+    merged = []
+    for z in range(final_max + 1):
+        a = old_avail[z] if z < len(old_avail) else []
+        b = new_avail[z] if z < len(new_avail) else []
+        merged.append(a + b)
+    layer = {
+        'tilejson': '2.1.0', 'format': 'quantized-mesh-1.0', 'version': '1.0.0',
+        'scheme': 'tms', 'projection': 'EPSG:4326',
+        'bounds': [-180, -90, 180, 90], 'minzoom': 0, 'maxzoom': final_max,
+        'tiles': ['{z}/{x}/{y}.terrain'], 'extensions': ['octvertexnormals'],
+        'available': merged,
+    }
+    with open(path, 'w') as f:
+        json.dump(layer, f)
+
+
+# ---------------------------------------------------------------- main
+
+def bbox_from_center(lat, lon, radius_km):
+    dlat = radius_km / 111.0
+    dlon = radius_km / (111.0 * max(0.1, np.cos(np.radians(lat))))
+    return [lon - dlon, lat - dlat, lon + dlon, lat + dlat]
+
+
+def select_cells(args, all_cells):
+    """Return (cells, clip_bbox). clip_bbox tightens the tile range to an area."""
+    if args.cell:
+        sel = []
+        for name in args.cell:
+            if name not in all_cells:
+                sys.exit('cell %s not found under %s' % (name, args.srtm_dir))
+            sel.append(all_cells[name])
+        return sel, None
+    clip = None
+    if args.center:
+        clip = bbox_from_center(args.center[0], args.center[1], args.radius_km)
+    elif args.bbox:
+        clip = list(args.bbox)
+    if clip:
+        w, s, e, n = clip
+        sel = []
+        for lo in range(int(np.floor(w)), int(np.ceil(e))):
+            for la in range(int(np.floor(s)), int(np.ceil(n))):
+                nm = cell_name(la, lo)
+                if nm in all_cells:
+                    sel.append(all_cells[nm])
+        return sel, clip
+    return list(all_cells.values()), None  # whole world
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--srtm-dir', required=True, help='dir of *.hgt.zip (recursive)')
+    ap.add_argument('--out', required=True, help='output tileset dir')
+    g = ap.add_mutually_exclusive_group()
+    g.add_argument('--cell', nargs='+', help='one or more cells, e.g. S36E149')
+    g.add_argument('--bbox', nargs=4, type=float, metavar=('W', 'S', 'E', 'N'))
+    g.add_argument('--center', nargs=2, type=float, metavar=('LAT', 'LON'),
+                   help='upgrade an area centred on lat/lon (with --radius-km)')
+    ap.add_argument('--radius-km', type=float, default=25.0,
+                    help='radius for --center (km, default 25)')
+    ap.add_argument('--srtm-res', type=int, choices=(1, 3), default=3,
+                    help='source resolution, sets default max zoom (1=SRTM1, 3=SRTM3)')
+    ap.add_argument('--max-zoom', type=int, default=None)
+    ap.add_argument('--min-zoom', type=int, default=0,
+                    help='lowest zoom to build (upgrades add only deep levels)')
+    ap.add_argument('--max-error', type=float, default=4.0,
+                    help='Delatin max vertical error (metres)')
+    ap.add_argument('--tile-px', type=int, default=256, help='max sample grid per tile')
+    ap.add_argument('--grid', type=int, default=65,
+                    help='regular NxN vertex grid per tile (crack-free); '
+                         '0 = adaptive Delatin (experimental: independent tiles can seam/crack)')
+    ap.add_argument('--force', action='store_true',
+                    help='overwrite existing tiles (default: skip = resume/upgrade)')
+    ap.add_argument('--coarse-dem', default=None,
+                    help='coarse global DEM (from build_coarse.py) for low zoom')
+    ap.add_argument('--coarse-max-zoom', type=int, default=8,
+                    help='use --coarse-dem for zoom <= this (default 8)')
+    ap.add_argument('--jobs', type=int, default=os.cpu_count())
+    args = ap.parse_args()
+
+    maxzoom = args.max_zoom if args.max_zoom is not None \
+        else DEFAULT_MAXZOOM[args.srtm_res]
+
+    all_cells = find_cells(args.srtm_dir)
+    if not all_cells:
+        sys.exit('no *.hgt.zip cells under %s' % args.srtm_dir)
+    cells, clip = select_cells(args, all_cells)
+    if not cells:
+        sys.exit('no cells selected')
+    print('cells=%d  zoom=%d-%d  jobs=%d  force=%s  out=%s'
+          % (len(cells), args.min_zoom, maxzoom, args.jobs, args.force, args.out),
+          flush=True)
+
+    os.makedirs(args.out, exist_ok=True)
+    vrt_path = os.path.join(args.out, '_source.vrt')
+    build_vrt(cells, vrt_path)
+
+    tiles, per_level = build_worklist(cells, args.min_zoom, maxzoom, clip)
+    tiles = sorted(tiles)
+    print('tiles to consider: %d' % len(tiles), flush=True)
+
+    write_layer_json(args.out, maxzoom, per_level, args.min_zoom)  # up-front (resume-safe)
+
+    t0 = time.time()
+    counts = {'ok': 0, 'skip': 0, 'empty': 0}
+    done = 0
+    with ProcessPoolExecutor(max_workers=args.jobs, initializer=_init_worker,
+                             initargs=(vrt_path, args.out, args.max_error,
+                                       args.tile_px, args.force, args.coarse_dem,
+                                       args.coarse_max_zoom, args.grid)) as ex:
+        for res in ex.map(render_tile, tiles, chunksize=16):
+            counts[res] = counts.get(res, 0) + 1
+            done += 1
+            if done % 500 == 0 or done == len(tiles):
+                dt = time.time() - t0
+                rate = done / dt if dt else 0
+                print('  %d/%d  ok=%d skip=%d empty=%d  %.0f tiles/s'
+                      % (done, len(tiles), counts['ok'], counts['skip'],
+                         counts['empty'], rate), flush=True)
+    print('done in %.1fs: %s' % (time.time() - t0, counts))
+    print('layer.json + tiles in %s' % args.out)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/components/CesiumViewer.vue
+++ b/src/components/CesiumViewer.vue
@@ -21,14 +21,11 @@
 
 <script>
 import {
-    Ion,
     Color,
     ProviderViewModel,
     UrlTemplateImageryProvider,
-    Viewer, createWorldTerrainAsync,
+    Viewer, CesiumTerrainProvider,
     PointPrimitiveCollection,
-    ImageryLayer,
-    IonImageryProvider,
     Entity,
     ScreenSpaceEventHandler,
     ScreenSpaceEventType,
@@ -84,12 +81,13 @@ import {
     isPointInPolygon
 } from './cesiumExtra/boundingPolygon.js'
 
-// Set Cesium token from runtime config injected by runtime-config.js
-const runtimeConfig = (typeof window !== 'undefined' && window.__APP_CONFIG__) || {}
-const cesiumToken = typeof runtimeConfig.VUE_APP_CESIUM_TOKEN === 'string'
-    ? runtimeConfig.VUE_APP_CESIUM_TOKEN.trim()
-    : ''
-Ion.defaultAccessToken = cesiumToken
+// Self-hosted terrain + non-ion imagery: no Cesium ion token required.
+// Default imagery is keyless Esri World Imagery (reliable, no key / domain / rate limits).
+const ESRI_WORLD_IMAGERY_URL =
+    'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'
+const ESRI_CREDIT = 'Imagery © Esri, Maxar, Earthstar Geographics'
+const MAPTILER_SATELLITE_URL =
+    'https://api.maptiler.com/tiles/satellite-v2/{z}/{x}/{y}.jpg?key=o3JREHNnXex8WSPPm2BU'
 
 const colorCoderMode = new ColorCoderMode(store)
 const colorCoderRange = new ColorCoderRange(store)
@@ -148,7 +146,13 @@ export default {
                     if (this.state.isOnline) {
                         this.viewer = this.createViewer(true)
                         if (this.state.vehicle !== 'boat') {
-                            this.viewer.terrainProvider = await createWorldTerrainAsync()
+                            try {
+                                // Self-hosted ArduPilot SRTM terrain (same origin), replaces ion.
+                                this.viewer.terrainProvider = await CesiumTerrainProvider.fromUrl('/quantized/')
+                            } catch (e) {
+                                // Fall back to the ellipsoid so the 3D view still works.
+                                console.warn('quantized terrain unavailable, using ellipsoid:', e)
+                            }
                         }
                     } else {
                         this.viewer = this.createViewer(false)
@@ -236,6 +240,7 @@ export default {
                 if (this.state.vehicle !== 'boat' && this.state.isOnline && this.correctedTrajectory.length > 0) {
                     const promise = sampleTerrainMostDetailed(this.viewer.terrainProvider, this.correctedTrajectory)
                     promise.then(async (result) => { await this.setup2(result) })
+                        .catch(() => this.setup2(this.correctedTrajectory))
                 } else {
                     this.setup2(this.correctedTrajectory)
                 }
@@ -266,6 +271,7 @@ export default {
                     'cesiumContainer',
                     {
                         homeButton: false,
+                        geocoder: false,
                         timeline: true,
                         animation: true,
                         requestRenderMode: true,
@@ -273,12 +279,11 @@ export default {
                         scene3DOnly: false,
                         selectionIndicator: false,
                         shadows: true,
-                        // eslint-disable-next-line
-                        baseLayer: new ImageryLayer.fromProviderAsync(
-                            IonImageryProvider.fromAssetId(3954)
-                        ),
+                        // No ion: custom keyless imagery list, and an empty terrain list so
+                        // the base layer picker can't fall back to ion's Cesium World Terrain.
                         imageryProviderViewModels: imageryProviders,
-                        selectedImageryProviderViewModel: this.sentinelProvider,
+                        selectedImageryProviderViewModel: this.esriProvider,
+                        terrainProviderViewModels: [],
                         orderIndependentTranslucency: false,
                         useBrowserRecommendedResolution: false
                     }
@@ -306,11 +311,22 @@ export default {
         },
 
         createAdditionalProviders () {
-            /*
-            *  Creates and returns the providers for viewing the Eniro, Statkart, and OpenSeaMap map layers
-            * */
-            // const imageryProviders = createDefaultImageryProviderViewModels()
+            // Base layer picker options. All keyless / non-ion. Esri satellite is the
+            // default (this.esriProvider); StatKart, MapTiler, Eniro and OpenSeaMap follow.
             const imageryProviders = []
+            this.esriProvider = new ProviderViewModel({
+                name: 'Satellite (Esri)',
+                iconUrl: require('../assets/maptiler.png').default,
+                tooltip: 'Esri World Imagery (satellite)',
+                creationFunction: function () {
+                    return new UrlTemplateImageryProvider({
+                        url: ESRI_WORLD_IMAGERY_URL,
+                        maximumLevel: 19,
+                        credit: ESRI_CREDIT
+                    })
+                }
+            })
+            imageryProviders.push(this.esriProvider)
             imageryProviders.push(new ProviderViewModel({
                 name: 'StatKart',
                 iconUrl: require('../assets/statkart.jpg').default,
@@ -328,31 +344,19 @@ export default {
                 tooltip: 'Maptiler satellite imagery http://maptiler.com/',
                 creationFunction: function () {
                     return new UrlTemplateImageryProvider({
-                        url: 'https://api.maptiler.com/tiles/satellite-v2/{z}/{x}/{y}.jpg?key=o3JREHNnXex8WSPPm2BU',
+                        url: MAPTILER_SATELLITE_URL,
                         minimumLevel: 0,
                         maximumLevel: 20,
                         credit: 'https://www.maptiler.com/copyright'
                     })
                 }
-            })
-            )
-            // save this one so it can be referenced when creating the cesium viewer
-            this.sentinelProvider = new ProviderViewModel({
-                name: 'Sentinel 2',
-                iconUrl: '/Widgets/Images/ImageryProviders/sentinel-2.png',
-                tooltip: 'Sentinel 2 Imagery',
-                creationFunction: function () {
-                    return ImageryLayer.fromProviderAsync(IonImageryProvider.fromAssetId(3954))
-                }
-            })
-            imageryProviders.push(this.sentinelProvider)
+            }))
             imageryProviders.push(new ProviderViewModel({
                 name: 'Eniro',
                 iconUrl: require('../assets/eniro.png').default,
                 tooltip: 'Eniro aerial imagery \nhttp://map.eniro.com/',
                 creationFunction: function () {
                     return new UrlTemplateImageryProvider({
-                        // url: 'http://map.eniro.com/geowebcache/service/tms1.0.0/map/{z}/{x}/{reverseY}.png',
                         url: '/eniro/{z}/{x}/{reverseY}.png',
                         credit: 'Map tiles by Eniro.'
                     })
@@ -373,7 +377,7 @@ export default {
                             credit: 'Map tiles by OpenStreetMap.'
                         }),
                         new UrlTemplateImageryProvider({
-                            url: 'http://tiles.openseamap.org/seamark/{z}/{x}/{y}.png',
+                            url: 'https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png',
                             credit: 'Map tiles by OpenSeaMap.'
                         })
                     ]
@@ -381,6 +385,7 @@ export default {
             }))
             return imageryProviders
         },
+
         async setup2 (updatedPositions) {
             try {
                 /*
@@ -476,7 +481,7 @@ export default {
             } else {
                 const promise = sampleTerrainMostDetailed(this.viewer.terrainProvider,
                     [position])
-                promise.then(update)
+                promise.then(update).catch(() => {})
             }
         },
         addCloseButton () {
@@ -1223,7 +1228,7 @@ export default {
             if (this.state.vehicle !== 'boat') {
                 sampleTerrainMostDetailed(this.viewer.terrainProvider, cesiumPoints, true).then((finalPoints) => {
                     this.plotMissionPoints(finalPoints, cesiumPointsOrig, points)
-                })
+                }).catch(() => this.plotMissionPoints(cesiumPointsOrig, cesiumPointsOrig, points))
             } else {
                 this.plotMissionPoints(cesiumPointsOrig, cesiumPointsOrig, points)
             }

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,9 +1,5 @@
 <template>
     <div id='vuewrapper' style="height: 100%;">
-        <div v-if="showCesiumTokenWarning" class="global-token-warning">
-            Warning: Cesium token is not configured. 3D map imagery and terrain may not load.
-            Configure it by setting VUE_APP_CESIUM_TOKEN in the environment.
-        </div>
         <template v-if="(state.mapLoading && !state.mapError) || state.plotLoading">
             <div id="waiting">
                 <atom-spinner
@@ -81,11 +77,6 @@ import { DjiDataExtractor } from '../tools/djiDataExtractor'
 import MagFitTool from '@/components/widgets/MagFitTool.vue'
 import EkfHelperTool from '@/components/widgets/EkfHelperTool.vue'
 import Vue from 'vue'
-
-const runtimeConfig = (typeof window !== 'undefined' && window.__APP_CONFIG__) || {}
-const cesiumToken = typeof runtimeConfig.VUE_APP_CESIUM_TOKEN === 'string'
-    ? runtimeConfig.VUE_APP_CESIUM_TOKEN.trim()
-    : ''
 
 export default {
     name: 'Home',
@@ -267,9 +258,6 @@ export default {
         EkfHelperTool
     },
     computed: {
-        showCesiumTokenWarning () {
-            return !cesiumToken
-        },
         mapOk () {
             return (this.state.flightModeChanges !== undefined &&
                     this.state.currentTrajectory !== undefined &&


### PR DESCRIPTION
Removes the paid Cesium ion dependency from the 3D map. Terrain now comes from a self-hosted quantized-mesh tileset served at the app origin (/quantized/), built from ArduPilot's existing SRTM data. No Cesium ion access token is required.

- terrain: CesiumTerrainProvider.fromUrl('/quantized/'), wrapped so an outage falls back to the ellipsoid instead of blanking the 3D view
- imagery: drop the ion Sentinel-2 layer and default to keyless Esri World Imagery. The base layer picker keeps the other keyless layers (StatKart, MapTiler, Eniro, OpenSeaMap); terrainProviderViewModels:[] and geocoder:false stop the picker/viewer pulling ion's World Terrain / Bing / geocoder
- remove the Ion import, token plumbing and the "token not configured" banner
- guard sampleTerrainMostDetailed with fallbacks so a sampling failure can't hang map init
- config/index.js: dev proxy for /quantized -> plot.ardupilot.org