### PR TITLE
scripts/terrain: bound tiler worker memory and add resume

### DIFF
--- a/scripts/terrain/README.md
+++ b/scripts/terrain/README.md
@@ -59,7 +59,30 @@ Area selection (mutually exclusive): `--cell S36E149 [...]`, `--bbox W S E N`, o
 (oceans skipped). Other flags: `--srtm-res {1,3}` (default 3), `--max-zoom`
 (default 13 for res 1, 11 for res 3), `--min-zoom` (>0 merges into existing availability
 for incremental upgrades), `--grid` (default 65), `--max-error` (adaptive path only),
-`--force` (rebuild existing tiles), `--jobs` (default = CPU count).
+`--force` (rebuild existing tiles), `--jobs` (default = CPU count),
+`--max-tasks-per-child` (recycle each worker after N chunks; default 400),
+`--start-index N` (skip the first N sorted tiles, to resume mid-run),
+`--no-layer-json` (don't write `layer.json`, e.g. when availability is hand-managed).
+
+## Memory / long runs
+
+Workers read windows from a single VRT mosaicking *all* SRTM cells, so GDAL would
+otherwise accumulate block + `/vsizip` cache unbounded as high-zoom tiles march across
+the globe (seen growing to ~2 GB/worker over hours). The fix is to cap GDAL in the parent
+(inherited by forked workers): `GDAL_CACHEMAX` (block cache) and
+`GDAL_MAX_DATASET_POOL_SIZE` (open `/vsizip` sources). On a small box also keep `--jobs`
+modest (each worker needs ~0.5 GB).
+
+`--max-tasks-per-child` (recycle workers) is **off by default and best left off**: if a
+worker errors while tearing down its open dataset, the result it was computing is never
+returned and `ProcessPoolExecutor.map` deadlocks the whole run. The GDAL caps bound memory
+without needing recycling. If you must reclaim more, prefer restarting the process in
+batches via `--start-index` (a full exit frees everything cleanly).
+
+Tile writes are atomic (temp file + `os.replace`), so the build is **kill-safe** — a `.terrain`
+file is never half-written. To resume after a kill: sweep stray `*.tmp*` files, then re-run
+with `--start-index` set just below the last logged counter (with `--force`, since the tiles
+already exist on disk).
 
 ## Serving (nginx)
 

--- a/scripts/terrain/srtm_to_qmesh.py
+++ b/scripts/terrain/srtm_to_qmesh.py
@@ -363,6 +363,12 @@ def select_cells(args, all_cells):
 
 
 def main():
+    # Bound GDAL memory so parallel workers don't accumulate unbounded block/VSI
+    # cache reading from the all-cells VRT. Set in the parent; inherited by forked
+    # workers (must be set before the first GDAL open in build_vrt).
+    os.environ.setdefault('GDAL_CACHEMAX', '128')              # MB block cache / proc
+    os.environ.setdefault('GDAL_MAX_DATASET_POOL_SIZE', '64')  # open /vsizip sources
+
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('--srtm-dir', required=True, help='dir of *.hgt.zip (recursive)')
@@ -392,6 +398,14 @@ def main():
     ap.add_argument('--coarse-max-zoom', type=int, default=8,
                     help='use --coarse-dem for zoom <= this (default 8)')
     ap.add_argument('--jobs', type=int, default=os.cpu_count())
+    ap.add_argument('--max-tasks-per-child', type=int, default=0,
+                    help='recycle each worker after this many chunks (0 = never; '
+                         'default). Avoid: a worker that errors on teardown can wedge '
+                         'the pool. Bound memory with the GDAL caps below instead.')
+    ap.add_argument('--start-index', type=int, default=0,
+                    help='skip the first N tiles of the sorted worklist (resume)')
+    ap.add_argument('--no-layer-json', action='store_true',
+                    help='do not write layer.json (preserve hand-managed availability)')
     args = ap.parse_args()
 
     maxzoom = args.max_zoom if args.max_zoom is not None \
@@ -413,17 +427,27 @@ def main():
 
     tiles, per_level = build_worklist(cells, args.min_zoom, maxzoom, clip)
     tiles = sorted(tiles)
+    offset = max(0, args.start_index)
+    if offset:
+        tiles = tiles[offset:]
+        print('resume: skipping first %d tiles' % offset, flush=True)
     print('tiles to consider: %d' % len(tiles), flush=True)
 
-    write_layer_json(args.out, maxzoom, per_level, args.min_zoom)  # up-front (resume-safe)
+    if not args.no_layer_json:
+        write_layer_json(args.out, maxzoom, per_level, args.min_zoom)  # up-front (resume-safe)
 
     t0 = time.time()
     counts = {'ok': 0, 'skip': 0, 'empty': 0}
     done = 0
+    total = len(tiles) + offset
+    pool_kw = {}
+    if args.max_tasks_per_child > 0:
+        pool_kw['max_tasks_per_child'] = args.max_tasks_per_child
     with ProcessPoolExecutor(max_workers=args.jobs, initializer=_init_worker,
                              initargs=(vrt_path, args.out, args.max_error,
                                        args.tile_px, args.force, args.coarse_dem,
-                                       args.coarse_max_zoom, args.grid)) as ex:
+                                       args.coarse_max_zoom, args.grid),
+                             **pool_kw) as ex:
         for res in ex.map(render_tile, tiles, chunksize=16):
             counts[res] = counts.get(res, 0) + 1
             done += 1
@@ -431,7 +455,7 @@ def main():
                 dt = time.time() - t0
                 rate = done / dt if dt else 0
                 print('  %d/%d  ok=%d skip=%d empty=%d  %.0f tiles/s'
-                      % (done, len(tiles), counts['ok'], counts['skip'],
+                      % (done + offset, total, counts['ok'], counts['skip'],
                          counts['empty'], rate), flush=True)
     print('done in %.1fs: %s' % (time.time() - t0, counts))
     print('layer.json + tiles in %s' % args.out)


### PR DESCRIPTION
Workers read from a VRT over all SRTM cells; GDAL block/vsizip cache grew unbounded as high-zoom tiles ranged across the globe (~2GB/worker over hours, OOMing a small box). Cap GDAL_CACHEMAX and GDAL_MAX_DATASET_POOL_SIZE in the parent (inherited by forked workers) to bound it without recycling.

A --max-tasks-per-child option can recycle workers but is off by default: a worker that errors while tearing down its open dataset never returns its result and ProcessPoolExecutor.map deadlocks the run. The GDAL caps are the primary mechanism; for more reclaim, restart in batches via --start-index.

Add --start-index (skip first N sorted tiles) and --no-layer-json so a killed run resumes without redoing finished tiles or clobbering hand-managed availability; progress logging stays in absolute tile numbers.