### PR TITLE
Allow plotting trajectory from SIM dataflash messages

### DIFF
--- a/src/tools/dataflashDataExtractor.js
+++ b/src/tools/dataflashDataExtractor.js
@@ -318,6 +318,9 @@ export class DataflashDataExtractor {
         if ('AHR2' in messages) {
             candidates.push('AHR2')
         }
+        if ('SIM' in messages) {
+            candidates.push('SIM')
+        }
         if ('GPS' in messages) {
             candidates.push('GPS')
         }
@@ -405,6 +408,45 @@ export class DataflashDataExtractor {
             }
             if (trajectory.length) {
                 ret.AHR2 = {
+                    startAltitude: startAltitude,
+                    trajectory: trajectory,
+                    timeTrajectory: timeTrajectory
+                }
+            }
+        }
+        if ('SIM' in messages && source === 'SIM') {
+            const trajectory = []
+            const timeTrajectory = {}
+            let startAltitude = null
+            const gpsData = messages.SIM
+            let start = 0
+            for (const i in gpsData.time_boot_ms) {
+                const delta = gpsData.time_boot_ms[i] - start
+                if (delta < 200) {
+                    continue
+                }
+                start = gpsData.time_boot_ms[i]
+                if (gpsData.Lat[i] !== 0) {
+                    if (startAltitude === null) {
+                        startAltitude = gpsData.Alt[i]
+                    }
+                    trajectory.push(
+                        [
+                            gpsData.Lng[i] * 1e-7,
+                            gpsData.Lat[i] * 1e-7,
+                            gpsData.Alt[i],
+                            gpsData.time_boot_ms[i]
+                        ]
+                    )
+                    timeTrajectory[gpsData.time_boot_ms[i]] = [
+                        gpsData.Lng[i] * 1e-7,
+                        gpsData.Lat[i] * 1e-7,
+                        gpsData.Alt[i],
+                        gpsData.time_boot_ms[i]]
+                }
+            }
+            if (trajectory.length) {
+                ret.SIM = {
                     startAltitude: startAltitude,
                     trajectory: trajectory,
                     timeTrajectory: timeTrajectory

--- a/src/tools/parsers/parser.worker.js
+++ b/src/tools/parsers/parser.worker.js
@@ -18,7 +18,7 @@ self.addEventListener('message', async function (event) {
             await parser.processData(data)
         } else {
             parser = new DataflashParser(true)
-            parser.processData(data, ['CMD', 'MSG', 'FILE', 'MODE', 'AHR2', 'ATT', 'GPS', 'POS',
+            parser.processData(data, ['CMD', 'MSG', 'FILE', 'MODE', 'AHR2', 'ATT', 'GPS', 'POS', 'SIM',
                 'XKQ1', 'XKQ', 'NKQ1', 'NKQ2', 'XKQ2', 'PARM', 'MSG', 'STAT', 'EV', 'XKF4', 'FNCE'])
         }
 


### PR DESCRIPTION
Add SIM as a trajectory source so the simulator ground-truth track can be plotted in the 3D view. Eagerly parse SIM in the worker so it is detected by extractTrajectorySources and appears in the source dropdown.