### PR TITLE
terrain: add regional USGS 1 m package builder

### DIFF
--- a/scripts/terrain/README.md
+++ b/scripts/terrain/README.md
@@ -32,7 +32,7 @@ pip install -r requirements.txt   # rasterio wheel bundles GDAL; no apt needed
 ## Regional USGS 3DEP 1 m package
 
 `terrain_to_qmesh.py` is the internal preparation path for a bounded Map3D
-terrain package. It queries The National Map, rejects newer project tiles that
+operational area. It queries The National Map, rejects newer project tiles that
 contain no data for the requested area, downloads the newest usable GeoTIFF,
 records the API response, source CRS, file size, and SHA-256, then builds the
 regional quantized-mesh levels. Source elevation values are preserved; the tool
@@ -44,6 +44,11 @@ records USGS NAVD88 metadata but does not perform a vertical conversion.
     --min-zoom 13 --max-zoom 18 \
     --out /data/terrain/site-name --jobs 4
 ```
+
+By default the tool expands the bounding box into the same per-level footprint
+used by Map3D's fine radius of two tiles and coarser ring width of one. The
+prepared source bounds and exact tile counts are recorded in `region.json`.
+Use `--fine-radius` and `--lod-ring` only when Map3D uses matching values.
 
 The output contains `region.json`, `terrain/layer.json`, `_source.tif`, the downloaded
 source GeoTIFFs under `sources/`, and `terrain/{z}/{x}/{y}.terrain`. A `.incomplete`

--- a/scripts/terrain/README.md
+++ b/scripts/terrain/README.md
@@ -45,8 +45,8 @@ records USGS NAVD88 metadata but does not perform a vertical conversion.
     --out /data/terrain/site-name --jobs 4
 ```
 
-The output contains `layer.json`, `sources.json`, `_source.tif`, the downloaded
-source GeoTIFFs under `sources/`, and `{z}/{x}/{y}.terrain`. A `.incomplete`
+The output contains `region.json`, `terrain/layer.json`, `_source.tif`, the downloaded
+source GeoTIFFs under `sources/`, and `terrain/{z}/{x}/{y}.terrain`. A `.incomplete`
 marker remains if preparation fails or is interrupted; `layer.json` is written
 only after all advertised terrain tiles exist. The tool refuses a requested
 area with substantial no-data coverage rather than publishing zero-height

--- a/scripts/terrain/README.md
+++ b/scripts/terrain/README.md
@@ -29,6 +29,34 @@ python3 -m venv .venv
 pip install -r requirements.txt   # rasterio wheel bundles GDAL; no apt needed
 ```
 
+## Regional USGS 3DEP 1 m package
+
+`terrain_to_qmesh.py` is the internal preparation path for a bounded Map3D
+terrain package. It queries The National Map, rejects newer project tiles that
+contain no data for the requested area, downloads the newest usable GeoTIFF,
+records the API response, source CRS, file size, and SHA-256, then builds the
+regional quantized-mesh levels. Source elevation values are preserved; the tool
+records USGS NAVD88 metadata but does not perform a vertical conversion.
+
+```bash
+./terrain_to_qmesh.py --usgs-1m \
+    --bbox -105.2755 39.9945 -105.2745 39.9955 \
+    --min-zoom 13 --max-zoom 18 \
+    --out /data/terrain/site-name --jobs 4
+```
+
+The output contains `layer.json`, `sources.json`, `_source.tif`, the downloaded
+source GeoTIFFs under `sources/`, and `{z}/{x}/{y}.terrain`. A `.incomplete`
+marker remains if preparation fails or is interrupted; `layer.json` is written
+only after all advertised terrain tiles exist. The tool refuses a requested
+area with substantial no-data coverage rather than publishing zero-height
+terrain.
+
+For an already-downloaded DEM, replace `--usgs-1m` with
+`--source-raster /path/to/dem.tif` and provide `--elevation-reference` if the
+source reference is known. Projected rasters are reprojected offline; Map3D is
+not expected to do GIS work at runtime.
+
 ## Build (two steps for a whole-world / large run)
 
 Low zooms read many cells at once, so for anything large first bake a **coarse global DEM**

--- a/scripts/terrain/srtm_to_qmesh.py
+++ b/scripts/terrain/srtm_to_qmesh.py
@@ -307,6 +307,34 @@ def build_worklist(cells, minzoom, maxzoom, clip=None, want_levels=True):
     return keys, per_level
 
 
+def build_worklist_for_bbox(bbox, minzoom, maxzoom, want_levels=True):
+    """Build the sorted tile set for one geographic bbox without SRTM cells."""
+    w, s, e, n = bbox
+    parts = []
+    for z in range(minzoom, maxzoom + 1):
+        x0, x1, y0, y1 = tile_range_for_bbox(z, w, s, e, n)
+        if x1 < x0 or y1 < y0:
+            continue
+        xs = np.arange(x0, x1 + 1, dtype=np.int64)
+        ys = np.arange(y0, y1 + 1, dtype=np.int64)
+        parts.append(((np.int64(z) << _KEY_ZSH)
+                      | (xs[:, None] << _KEY_XSH)
+                      | ys[None, :]).ravel())
+    if not parts:
+        return np.empty(0, dtype=np.int64), ({} if want_levels else None)
+    keys = np.concatenate(parts)
+    per_level = None
+    if want_levels:
+        per_level = {}
+        zz = keys >> _KEY_ZSH
+        xx = (keys >> _KEY_XSH) & _KEY_MASK
+        yy = keys & _KEY_MASK
+        for z in range(minzoom, maxzoom + 1):
+            mask = zz == z
+            per_level[z] = list(zip(xx[mask].tolist(), yy[mask].tolist()))
+    return keys, per_level
+
+
 def availability(per_level, maxzoom):
     """Row-merge each level's (x,y) tiles into rectangles for layer.json."""
     out = []
@@ -328,7 +356,8 @@ def availability(per_level, maxzoom):
     return out
 
 
-def write_layer_json(out_dir, maxzoom, per_level, min_zoom):
+def write_layer_json(out_dir, maxzoom, per_level, min_zoom, bounds=None,
+                     output_minzoom=None, metadata=None):
     """Write layer.json. For an upgrade run (min_zoom > 0) availability is merged into
     the existing tileset so the base levels are kept (Cesium ORs the rectangle lists).
     A full run (min_zoom == 0) writes fresh availability so it never advertises stale
@@ -352,12 +381,18 @@ def write_layer_json(out_dir, maxzoom, per_level, min_zoom):
     layer = {
         'tilejson': '2.1.0', 'format': 'quantized-mesh-1.0', 'version': '1.0.0',
         'scheme': 'tms', 'projection': 'EPSG:4326',
-        'bounds': [-180, -90, 180, 90], 'minzoom': 0, 'maxzoom': final_max,
+        'bounds': list(bounds) if bounds is not None else [-180, -90, 180, 90],
+        'minzoom': 0 if output_minzoom is None else output_minzoom,
+        'maxzoom': final_max,
         'tiles': ['{z}/{x}/{y}.terrain'], 'extensions': ['octvertexnormals'],
         'available': merged,
     }
-    with open(path, 'w') as f:
+    if metadata is not None:
+        layer['metadata'] = metadata
+    tmp = path + '.tmp'
+    with open(tmp, 'w') as f:
         json.dump(layer, f)
+    os.replace(tmp, path)
 
 
 # ---------------------------------------------------------------- main

--- a/scripts/terrain/srtm_to_qmesh.py
+++ b/scripts/terrain/srtm_to_qmesh.py
@@ -201,7 +201,9 @@ def render_tile(zxy):
         rr, cc = np.mgrid[0:g, 0:g]
         lon = west + cc.ravel() * sx
         lat = north - rr.ravel() * sy
-        pos = np.column_stack([lon, lat, arr.ravel()]).astype(np.float32)
+        # Keep geographic coordinates in float64. At zoom 18/19, float32
+        # longitude can collapse adjacent vertices and produce zero normals.
+        pos = np.column_stack([lon, lat, arr.ravel()])
         idx = _GRID_IDX
     else:
         # Adaptive Delatin mesh, with the read clamped to the data extent so low-zoom
@@ -238,7 +240,7 @@ def render_tile(zxy):
         W, H = ow, oh
         lon = west + verts[:, 0] / (W - 1) * (east - west)
         lat = north - verts[:, 1] / (H - 1) * (north - south)
-        pos = np.column_stack([lon, lat, verts[:, 2]]).astype(np.float32)
+        pos = np.column_stack([lon, lat, verts[:, 2]])
         idx = tris.astype(np.uint32)
     ext = VertexNormalsExtension(indices=idx, positions=pos)
     buf = io.BytesIO()
@@ -261,6 +263,10 @@ def render_tile(zxy):
 _KEY_ZSH = 40
 _KEY_XSH = 20
 _KEY_MASK = (1 << 20) - 1
+
+
+def pack_key(z, x, y):
+    return (int(z) << _KEY_ZSH) | (int(x) << _KEY_XSH) | int(y)
 
 
 def _decode_key(k):

--- a/scripts/terrain/srtm_to_qmesh.py
+++ b/scripts/terrain/srtm_to_qmesh.py
@@ -180,6 +180,8 @@ def render_tile(zxy):
     # Low zoom reads the coarse global DEM (cheap, has overviews); high zoom reads
     # full-res SRTM (each tile then covers only ~1 cell, so the window is bounded).
     ds = _DS_COARSE if (_DS_COARSE is not None and z <= _COARSE_MAXZ) else _DS
+    if ds is None:
+        raise RuntimeError('terrain worker has no open DEM')
     west, south, east, north = tile_bounds(z, x, y)
 
     if _GRID > 0:
@@ -194,10 +196,15 @@ def render_tile(zxy):
         # data extent (coverage edges); interior tiles read directly (~12x faster).
         db = ds.bounds
         inside = ew >= db.left and es >= db.bottom and ee <= db.right and en <= db.top
-        arr = ds.read(1, window=from_bounds(ew, es, ee, en, ds.transform),
-                      out_shape=(g, g), resampling=Resampling.bilinear,
-                      boundless=not inside, fill_value=0).astype(np.float32)
-        arr[arr < -1000.0] = 0.0
+        sampled = ds.read(
+            1, window=from_bounds(ew, es, ee, en, ds.transform),
+            out_shape=(g, g), resampling=Resampling.bilinear,
+            boundless=not inside, masked=True)
+        if np.ma.getmaskarray(sampled).any():
+            return 'empty'
+        arr = np.asarray(sampled.data, dtype=np.float32)
+        if not np.isfinite(arr).all():
+            return 'empty'
         rr, cc = np.mgrid[0:g, 0:g]
         lon = west + cc.ravel() * sx
         lat = north - rr.ravel() * sy
@@ -213,6 +220,8 @@ def render_tile(zxy):
         isb, itn = max(south, db.bottom), min(north, db.top)
         if ie <= iw or itn <= isb:
             return 'empty'  # tile doesn't overlap any source data
+        if iw > west or ie < east or isb > south or itn < north:
+            return 'empty'  # do not publish a partially covered tile
         resx, resy = ds.res
         ow = max(2, min(int(round((east - west) / resx)) + 1, _TILE_PX))
         oh = max(2, min(int(round((north - south) / resy)) + 1, _TILE_PX))
@@ -228,10 +237,15 @@ def render_tile(zxy):
         be = west + cx1 / (ow - 1) * (east - west)
         bn = north - ry0 / (oh - 1) * (north - south)
         bs = north - ry1 / (oh - 1) * (north - south)
-        sub = ds.read(1, window=from_bounds(bw, bs, be, bn, ds.transform),
-                      out_shape=(sh, sw), resampling=Resampling.bilinear,
-                      boundless=True, fill_value=0).astype(np.float32)
-        sub[sub < -1000.0] = 0.0
+        sampled = ds.read(
+            1, window=from_bounds(bw, bs, be, bn, ds.transform),
+            out_shape=(sh, sw), resampling=Resampling.bilinear,
+            boundless=False, masked=True)
+        if np.ma.getmaskarray(sampled).any():
+            return 'empty'
+        sub = np.asarray(sampled.data, dtype=np.float32)
+        if not np.isfinite(sub).all():
+            return 'empty'
         arr[ry0:ry0 + sh, cx0:cx0 + sw] = sub
         tin = Delatin(arr, max_error=_MAX_ERROR)
         verts, tris = tin.vertices, tin.triangles

--- a/scripts/terrain/srtm_to_qmesh.py
+++ b/scripts/terrain/srtm_to_qmesh.py
@@ -357,15 +357,16 @@ def availability(per_level, maxzoom):
 
 
 def write_layer_json(out_dir, maxzoom, per_level, min_zoom, bounds=None,
-                     output_minzoom=None, metadata=None):
-    """Write layer.json. For an upgrade run (min_zoom > 0) availability is merged into
-    the existing tileset so the base levels are kept (Cesium ORs the rectangle lists).
-    A full run (min_zoom == 0) writes fresh availability so it never advertises stale
-    tiles from a previous build."""
+                     output_minzoom=None, metadata=None, merge_existing=True):
+    """Write layer.json.
+
+    SRTM upgrade runs merge existing availability. Regional packages pass
+    merge_existing=False so a rebuild cannot advertise stale tiles.
+    """
     path = os.path.join(out_dir, 'layer.json')
     new_avail = availability(per_level, maxzoom)
     old_avail, old_max = [], -1
-    if min_zoom > 0 and os.path.exists(path):
+    if merge_existing and min_zoom > 0 and os.path.exists(path):
         try:
             old = json.load(open(path))
             old_avail = old.get('available', [])

--- a/scripts/terrain/terrain_to_qmesh.py
+++ b/scripts/terrain/terrain_to_qmesh.py
@@ -378,7 +378,8 @@ def prepare(args):
     }
     qmesh.write_layer_json(
         terrain_dir, args.max_zoom, per_level, args.min_zoom,
-        bounds=bbox, output_minzoom=args.min_zoom, metadata=metadata)
+        bounds=bbox, output_minzoom=args.min_zoom, metadata=metadata,
+        merge_existing=False)
     incomplete.unlink(missing_ok=True)
     print('complete: %s (%s)' % (package_dir, counts), flush=True)
 

--- a/scripts/terrain/terrain_to_qmesh.py
+++ b/scripts/terrain/terrain_to_qmesh.py
@@ -243,6 +243,24 @@ def sha256_file(path):
     return digest.hexdigest()
 
 
+def response_identity(response):
+    headers = response.headers
+    content_length = headers.get('Content-Length')
+    return {
+        'contentLength': int(content_length) if content_length else None,
+        'contentType': headers.get('Content-Type'),
+        'etag': headers.get('ETag'),
+        'lastModified': headers.get('Last-Modified'),
+    }
+
+
+def remote_identity(url):
+    request = Request(
+        url, headers={'User-Agent': 'MAVProxy-terrain-prep/1'}, method='HEAD')
+    with urlopen(request, timeout=60) as response:
+        return response_identity(response)
+
+
 def download_product(product, download_dir, force=False):
     url = product['downloadURL']
     name = Path(unquote(urlparse(url).path)).name
@@ -250,7 +268,17 @@ def download_product(product, download_dir, force=False):
         raise RuntimeError('USGS product has no filename: %s' % url)
     path = download_dir / name
     expected_size = int(product.get('sizeInBytes') or 0)
-    if path.exists() and not force and (not expected_size or path.stat().st_size == expected_size):
+    identity = None
+    reuse = path.exists() and not force and (
+        not expected_size or path.stat().st_size == expected_size)
+    if path.exists() and not force and not reuse:
+        try:
+            identity = remote_identity(url)
+        except OSError:
+            identity = None
+        live_size = identity.get('contentLength') if identity else None
+        reuse = live_size is not None and path.stat().st_size == live_size
+    if reuse:
         print('reuse %s' % path, flush=True)
     else:
         part = path.with_suffix(path.suffix + '.part')
@@ -258,14 +286,25 @@ def download_product(product, download_dir, force=False):
         print('download %s' % url, flush=True)
         request = Request(url, headers={'User-Agent': 'MAVProxy-terrain-prep/1'})
         with urlopen(request, timeout=120) as response, open(part, 'wb') as output:
+            identity = response_identity(response)
             shutil.copyfileobj(response, output, length=1024 * 1024)
-        if expected_size and part.stat().st_size != expected_size:
+        downloaded_size = part.stat().st_size
+        live_size = identity['contentLength']
+        if live_size is not None and downloaded_size != live_size:
+            part.unlink(missing_ok=True)
+            raise RuntimeError('download size mismatch for %s' % url)
+        if live_size is None and expected_size and downloaded_size != expected_size:
             part.unlink(missing_ok=True)
             raise RuntimeError('download size mismatch for %s' % url)
         os.replace(part, path)
     record = dict(product)
     record['localFile'] = path.name
     record['downloadedBytes'] = path.stat().st_size
+    record['httpIdentity'] = identity
+    live_size = identity.get('contentLength') if identity else None
+    record['catalogLiveSizeDiscrepancyBytes'] = (
+        live_size - expected_size
+        if live_size is not None and expected_size else None)
     record['sha256'] = sha256_file(path)
     return path, record
 

--- a/scripts/terrain/terrain_to_qmesh.py
+++ b/scripts/terrain/terrain_to_qmesh.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Prepare a regional quantized-mesh package from USGS 3DEP 1 m or a local raster.
+
+The USGS path queries The National Map for a bounding box, keeps the newest
+GeoTIFF for each 10 km tile, downloads it, records provenance and checksums,
+reprojects/mosaics the source to EPSG:4326, and uses the existing ArduPilot
+quantized-mesh encoder. Source elevation values are preserved without vertical
+datum conversion.
+"""
+
+import argparse
+from contextlib import ExitStack
+from concurrent.futures import ProcessPoolExecutor
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import sys
+import time
+from urllib.parse import urlencode, unquote, urlparse
+from urllib.request import Request, urlopen
+
+import numpy as np
+import rasterio
+from rasterio.enums import Resampling
+from rasterio.merge import merge
+from rasterio.vrt import WarpedVRT
+
+import srtm_to_qmesh as qmesh
+
+TNM_PRODUCTS_URL = 'https://tnmaccess.nationalmap.gov/api/v1/products'
+USGS_1M_DATASET = 'Digital Elevation Model (DEM) 1 meter'
+USGS_ELEVATION_REFERENCE = 'NAVD88 metres as supplied by USGS; no vertical conversion applied'
+TILE_NAME_RE = re.compile(r'\bx(\d+)y(\d+)\b', re.IGNORECASE)
+
+
+def validate_bbox(bbox):
+    west, south, east, north = bbox
+    if not (-180.0 <= west < east <= 180.0):
+        raise ValueError('bbox must satisfy -180 <= WEST < EAST <= 180')
+    if not (-90.0 <= south < north <= 90.0):
+        raise ValueError('bbox must satisfy -90 <= SOUTH < NORTH <= 90')
+    return [float(value) for value in bbox]
+
+
+def product_key(product):
+    match = TILE_NAME_RE.search(product.get('title', ''))
+    if match:
+        return 'tile', int(match.group(1)), int(match.group(2))
+    bounds = product.get('boundingBox') or {}
+    return ('bounds',
+            round(float(bounds.get('minX', 0.0)), 3),
+            round(float(bounds.get('minY', 0.0)), 3),
+            round(float(bounds.get('maxX', 0.0)), 3),
+            round(float(bounds.get('maxY', 0.0)), 3))
+
+
+def select_current_products(products, probe=None):
+    """Keep the newest usable product for each USGS 10 km tile."""
+    grouped = {}
+    for product in products:
+        url = product.get('downloadURL')
+        if not url or not url.lower().split('?', 1)[0].endswith(('.tif', '.tiff')):
+            continue
+        key = product_key(product)
+        grouped.setdefault(key, []).append(product)
+    selected = []
+    for key in sorted(grouped):
+        candidates = sorted(
+            grouped[key], key=lambda item: item.get('publicationDate', ''),
+            reverse=True)
+        if probe is None:
+            selected.append(candidates[0])
+            continue
+        for candidate in candidates:
+            if probe(candidate):
+                selected.append(candidate)
+                break
+    return selected
+
+
+def product_has_data(product, bbox):
+    """Probe the requested overlap through GDAL HTTP ranges before downloading."""
+    product_bounds = product.get('boundingBox') or {}
+    west = max(bbox[0], float(product_bounds.get('minX', bbox[0])))
+    south = max(bbox[1], float(product_bounds.get('minY', bbox[1])))
+    east = min(bbox[2], float(product_bounds.get('maxX', bbox[2])))
+    north = min(bbox[3], float(product_bounds.get('maxY', bbox[3])))
+    if west >= east or south >= north:
+        return False
+    points = []
+    for fy in (0.2, 0.5, 0.8):
+        for fx in (0.2, 0.5, 0.8):
+            points.append((west + fx * (east - west),
+                           south + fy * (north - south)))
+    try:
+        with rasterio.open(product['downloadURL']) as source:
+            from rasterio.warp import transform
+            xs, ys = transform(
+                'EPSG:4326', source.crs,
+                [point[0] for point in points],
+                [point[1] for point in points])
+            usable = 0
+            for value in source.sample(zip(xs, ys), masked=True):
+                height = value[0]
+                if np.ma.is_masked(height) or not np.isfinite(height):
+                    continue
+                if source.nodata is not None and height == source.nodata:
+                    continue
+                usable += 1
+    except Exception as error:
+        print('probe failed for %s: %s' % (product.get('title', 'product'), error),
+              flush=True)
+        return False
+    if usable == len(points):
+        print('use %s (%d/9 probe samples valid)' %
+              (product.get('title', 'product'), usable), flush=True)
+    elif usable:
+        print('skip partial %s (%d/9 probe samples valid)' %
+              (product.get('title', 'product'), usable), flush=True)
+    else:
+        print('skip empty %s' % product.get('title', 'product'), flush=True)
+    return usable == len(points)
+
+
+def query_usgs_products(bbox):
+    all_items = []
+    offset = 0
+    page_size = 500
+    while True:
+        params = {
+            'bbox': ','.join(str(value) for value in bbox),
+            'datasets': USGS_1M_DATASET,
+            'prodFormats': 'GeoTIFF',
+            'outputFormat': 'JSON',
+            'max': page_size,
+            'offset': offset,
+        }
+        url = '%s?%s' % (TNM_PRODUCTS_URL, urlencode(params))
+        request = Request(url, headers={'User-Agent': 'MAVProxy-terrain-prep/1'})
+        with urlopen(request, timeout=60) as response:
+            page = json.load(response)
+        items = page.get('items', [])
+        all_items.extend(items)
+        offset += len(items)
+        if not items or offset >= int(page.get('total', len(all_items))):
+            break
+    return select_current_products(
+        all_items, probe=lambda product: product_has_data(product, bbox)), url
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, 'rb') as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download_product(product, download_dir, force=False):
+    url = product['downloadURL']
+    name = Path(unquote(urlparse(url).path)).name
+    if not name:
+        raise RuntimeError('USGS product has no filename: %s' % url)
+    path = download_dir / name
+    expected_size = int(product.get('sizeInBytes') or 0)
+    if path.exists() and not force and (not expected_size or path.stat().st_size == expected_size):
+        print('reuse %s' % path, flush=True)
+    else:
+        part = path.with_suffix(path.suffix + '.part')
+        part.unlink(missing_ok=True)
+        print('download %s' % url, flush=True)
+        request = Request(url, headers={'User-Agent': 'MAVProxy-terrain-prep/1'})
+        with urlopen(request, timeout=120) as response, open(part, 'wb') as output:
+            shutil.copyfileobj(response, output, length=1024 * 1024)
+        if expected_size and part.stat().st_size != expected_size:
+            part.unlink(missing_ok=True)
+            raise RuntimeError('download size mismatch for %s' % url)
+        os.replace(part, path)
+    record = dict(product)
+    record['localFile'] = path.name
+    record['downloadedBytes'] = path.stat().st_size
+    record['sha256'] = sha256_file(path)
+    return path, record
+
+
+def atomic_json(path, value):
+    tmp = path.with_suffix(path.suffix + '.tmp')
+    with open(tmp, 'w') as output:
+        json.dump(value, output, indent=2, sort_keys=True)
+        output.write('\n')
+    os.replace(tmp, path)
+
+
+def raster_record(path):
+    with rasterio.open(path) as source:
+        return {
+            'file': path.name,
+            'crs': source.crs.to_string() if source.crs else None,
+            'bounds': list(source.bounds),
+            'resolution': [abs(source.res[0]), abs(source.res[1])],
+            'width': source.width,
+            'height': source.height,
+            'dtype': source.dtypes[0],
+            'nodata': source.nodata,
+        }
+
+
+def build_mosaic(source_paths, destination, bounds):
+    destination.unlink(missing_ok=True)
+    records = [raster_record(path) for path in source_paths]
+    with ExitStack() as stack:
+        warped = []
+        for path in source_paths:
+            source = stack.enter_context(rasterio.open(path))
+            if source.crs is None:
+                raise RuntimeError('%s has no coordinate reference system' % path)
+            warped.append(stack.enter_context(WarpedVRT(
+                source, crs='EPSG:4326', resampling=Resampling.bilinear)))
+        merge(
+            warped,
+            bounds=bounds,
+            dtype='float32',
+            nodata=-32768.0,
+            resampling=Resampling.bilinear,
+            use_highest_res=True,
+            mem_limit=128,
+            dst_path=destination,
+            dst_kwds={
+                'driver': 'GTiff',
+                'compress': 'deflate',
+                'tiled': True,
+                'blockxsize': 512,
+                'blockysize': 512,
+                'BIGTIFF': 'IF_SAFER',
+            })
+    return records, raster_record(destination)
+
+
+def mosaic_valid_fraction(path, bbox):
+    with rasterio.open(path) as source:
+        window = rasterio.windows.from_bounds(*bbox, transform=source.transform)
+        sample = source.read(
+            1, window=window, out_shape=(128, 128),
+            resampling=Resampling.nearest, boundless=True, masked=True)
+    return float(np.count_nonzero(~np.ma.getmaskarray(sample))) / sample.size
+
+
+def render_tiles(source_path, out_dir, bbox, minzoom, maxzoom, jobs, grid,
+                 max_error, tile_px, force):
+    keys, _expected = qmesh.build_worklist_for_bbox(
+        bbox, minzoom, maxzoom, want_levels=False)
+    total = len(keys)
+    if total == 0:
+        raise RuntimeError('bbox produced no terrain tiles')
+    print('tiles=%d zoom=%d-%d jobs=%d' % (total, minzoom, maxzoom, jobs), flush=True)
+    per_level = {zoom: [] for zoom in range(minzoom, maxzoom + 1)}
+    counts = {'ok': 0, 'skip': 0, 'empty': 0}
+    started = time.time()
+    with ProcessPoolExecutor(
+            max_workers=jobs,
+            initializer=qmesh._init_worker,
+            initargs=(str(source_path), str(out_dir), max_error, tile_px,
+                      force, None, -1, grid)) as executor:
+        batch_size = 100000
+        done = 0
+        for start in range(0, total, batch_size):
+            batch = [qmesh._decode_key(key)
+                     for key in keys[start:start + batch_size].tolist()]
+            for tile, result in zip(batch, executor.map(qmesh.render_tile, batch, chunksize=16)):
+                counts[result] = counts.get(result, 0) + 1
+                done += 1
+                if result in ('ok', 'skip'):
+                    zoom, x, y = tile
+                    per_level[zoom].append((x, y))
+                if done % 100 == 0 or done == total:
+                    print('  %d/%d ok=%d skip=%d empty=%d' %
+                          (done, total, counts['ok'], counts['skip'], counts['empty']),
+                          flush=True)
+    if counts['ok'] + counts['skip'] == 0:
+        raise RuntimeError('source produced no terrain tiles')
+    print('rendered in %.1fs' % (time.time() - started), flush=True)
+    return per_level, counts
+
+
+def prepare(args):
+    bbox = validate_bbox(args.bbox)
+    if args.min_zoom < 0 or args.max_zoom > 19 or args.min_zoom > args.max_zoom:
+        raise ValueError('zoom range must satisfy 0 <= MIN <= MAX <= 19')
+
+    out_dir = Path(args.out).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    incomplete = out_dir / '.incomplete'
+    incomplete.write_text('terrain package build in progress\n')
+
+    manifest = {
+        'dataset': USGS_1M_DATASET if args.usgs_1m else 'local raster',
+        'requestedBounds': bbox,
+        'elevationReference': (USGS_ELEVATION_REFERENCE if args.usgs_1m
+                               else args.elevation_reference),
+        'productsQuery': None,
+        'products': [],
+        'sourceRasters': [],
+    }
+
+    if args.usgs_1m:
+        products, query_url = query_usgs_products(bbox)
+        if not products:
+            raise RuntimeError('USGS has no 1 m GeoTIFF products for this bbox')
+        if len(products) > args.max_products:
+            raise RuntimeError('%d USGS tiles exceed --max-products %d' %
+                               (len(products), args.max_products))
+        print('USGS products selected: %d' % len(products), flush=True)
+        download_dir = out_dir / 'sources'
+        download_dir.mkdir(exist_ok=True)
+        source_paths = []
+        records = []
+        for product in products:
+            path, record = download_product(product, download_dir, args.force_download)
+            source_paths.append(path)
+            records.append(record)
+        manifest['productsQuery'] = query_url
+        manifest['products'] = records
+    else:
+        source_path = Path(args.source_raster).resolve()
+        if not source_path.is_file():
+            raise RuntimeError('source raster not found: %s' % source_path)
+        source_paths = [source_path]
+
+    x0, x1, y0, y1 = qmesh.tile_range_for_bbox(args.max_zoom, *bbox)
+    first_bounds = qmesh.tile_bounds(args.max_zoom, x0, y0)
+    last_bounds = qmesh.tile_bounds(args.max_zoom, x1, y1)
+    mosaic_bounds = [first_bounds[0], first_bounds[1],
+                     last_bounds[2], last_bounds[3]]
+    mosaic_path = out_dir / '_source.tif'
+    source_records, mosaic_record = build_mosaic(
+        source_paths, mosaic_path, mosaic_bounds)
+    manifest['sourceRasters'] = source_records
+    manifest['mosaic'] = mosaic_record
+    valid_fraction = mosaic_valid_fraction(mosaic_path, bbox)
+    manifest['mosaic']['requestedBoundsValidFraction'] = valid_fraction
+    if valid_fraction < 0.99:
+        atomic_json(out_dir / 'sources.json', manifest)
+        raise RuntimeError(
+            'source data covers only %.1f%% of the requested bbox; choose a smaller '
+            'zone or another source raster' % (100.0 * valid_fraction))
+    atomic_json(out_dir / 'sources.json', manifest)
+
+    per_level, counts = render_tiles(
+        mosaic_path, out_dir, bbox, args.min_zoom, args.max_zoom,
+        args.jobs, args.grid, args.max_error, args.tile_px, args.force)
+    metadata = {
+        'dataset': manifest['dataset'],
+        'elevationReference': manifest['elevationReference'],
+        'sourceManifest': 'sources.json',
+        'sourceCRS': [record['crs'] for record in source_records],
+        'tileCounts': {str(zoom): len(per_level[zoom]) for zoom in per_level},
+    }
+    qmesh.write_layer_json(
+        out_dir, args.max_zoom, per_level, args.min_zoom,
+        bounds=bbox, output_minzoom=args.min_zoom, metadata=metadata)
+    incomplete.unlink(missing_ok=True)
+    print('complete: %s (%s)' % (out_dir, counts), flush=True)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument('--usgs-1m', action='store_true',
+                        help='query and download current USGS 3DEP 1 m GeoTIFFs')
+    source.add_argument('--source-raster', help='local georeferenced DEM raster')
+    parser.add_argument('--bbox', nargs=4, required=True, type=float,
+                        metavar=('WEST', 'SOUTH', 'EAST', 'NORTH'))
+    parser.add_argument('--out', required=True, help='output terrain package directory')
+    parser.add_argument('--min-zoom', type=int, default=13)
+    parser.add_argument('--max-zoom', type=int, default=18)
+    parser.add_argument('--jobs', type=int, default=os.cpu_count() or 1)
+    parser.add_argument('--grid', type=int, default=65)
+    parser.add_argument('--tile-px', type=int, default=256)
+    parser.add_argument('--max-error', type=float, default=4.0)
+    parser.add_argument('--max-products', type=int, default=100,
+                        help='abort before downloading more than this many USGS tiles')
+    parser.add_argument('--elevation-reference', default='source values; no vertical conversion')
+    parser.add_argument('--force', action='store_true', help='rebuild existing terrain tiles')
+    parser.add_argument('--force-download', action='store_true',
+                        help='redownload existing source GeoTIFFs')
+    return parser.parse_args(argv)
+
+
+def main():
+    try:
+        prepare(parse_args())
+    except (OSError, RuntimeError, ValueError) as error:
+        sys.exit('terrain preparation failed: %s' % error)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/terrain/terrain_to_qmesh.py
+++ b/scripts/terrain/terrain_to_qmesh.py
@@ -399,7 +399,9 @@ def prepare(args):
         'elevationReference': (USGS_ELEVATION_REFERENCE if args.usgs_1m
                                else args.elevation_reference),
         'verticalValuesTransformed': False,
-        'nodataPolicy': 'refuse package when sampled AOI validity is below 99 percent',
+        'nodataPolicy': (
+            'reject package when sampled prepared-bounds validity is below 99 percent; '
+            'omit emitted tiles containing declared nodata or non-finite samples'),
         'productsQuery': None,
         'products': [],
         'sourceRasters': [],

--- a/scripts/terrain/terrain_to_qmesh.py
+++ b/scripts/terrain/terrain_to_qmesh.py
@@ -11,6 +11,7 @@ datum conversion.
 import argparse
 from contextlib import ExitStack
 from concurrent.futures import ProcessPoolExecutor
+from datetime import datetime, timezone
 import hashlib
 import json
 import os
@@ -290,16 +291,26 @@ def prepare(args):
     if args.min_zoom < 0 or args.max_zoom > 19 or args.min_zoom > args.max_zoom:
         raise ValueError('zoom range must satisfy 0 <= MIN <= MAX <= 19')
 
-    out_dir = Path(args.out).resolve()
-    out_dir.mkdir(parents=True, exist_ok=True)
-    incomplete = out_dir / '.incomplete'
+    package_dir = Path(args.out).resolve()
+    terrain_dir = package_dir / 'terrain'
+    package_dir.mkdir(parents=True, exist_ok=True)
+    terrain_dir.mkdir(exist_ok=True)
+    incomplete = package_dir / '.incomplete'
     incomplete.write_text('terrain package build in progress\n')
 
     manifest = {
+        'schemaVersion': 1,
+        'builtAt': datetime.now(timezone.utc).isoformat(),
+        'converter': {
+            'file': Path(__file__).name,
+            'sha256': sha256_file(Path(__file__)),
+        },
         'dataset': USGS_1M_DATASET if args.usgs_1m else 'local raster',
-        'requestedBounds': bbox,
+        'operationalAOI': bbox,
         'elevationReference': (USGS_ELEVATION_REFERENCE if args.usgs_1m
                                else args.elevation_reference),
+        'verticalValuesTransformed': False,
+        'nodataPolicy': 'refuse package when sampled AOI validity is below 99 percent',
         'productsQuery': None,
         'products': [],
         'sourceRasters': [],
@@ -313,7 +324,7 @@ def prepare(args):
             raise RuntimeError('%d USGS tiles exceed --max-products %d' %
                                (len(products), args.max_products))
         print('USGS products selected: %d' % len(products), flush=True)
-        download_dir = out_dir / 'sources'
+        download_dir = package_dir / 'sources'
         download_dir.mkdir(exist_ok=True)
         source_paths = []
         records = []
@@ -334,7 +345,8 @@ def prepare(args):
     last_bounds = qmesh.tile_bounds(args.max_zoom, x1, y1)
     mosaic_bounds = [first_bounds[0], first_bounds[1],
                      last_bounds[2], last_bounds[3]]
-    mosaic_path = out_dir / '_source.tif'
+    manifest['preparedBounds'] = mosaic_bounds
+    mosaic_path = package_dir / '_source.tif'
     source_records, mosaic_record = build_mosaic(
         source_paths, mosaic_path, mosaic_bounds)
     manifest['sourceRasters'] = source_records
@@ -342,27 +354,33 @@ def prepare(args):
     valid_fraction = mosaic_valid_fraction(mosaic_path, bbox)
     manifest['mosaic']['requestedBoundsValidFraction'] = valid_fraction
     if valid_fraction < 0.99:
-        atomic_json(out_dir / 'sources.json', manifest)
+        atomic_json(package_dir / 'region.json', manifest)
         raise RuntimeError(
             'source data covers only %.1f%% of the requested bbox; choose a smaller '
             'zone or another source raster' % (100.0 * valid_fraction))
-    atomic_json(out_dir / 'sources.json', manifest)
-
     per_level, counts = render_tiles(
-        mosaic_path, out_dir, bbox, args.min_zoom, args.max_zoom,
+        mosaic_path, terrain_dir, bbox, args.min_zoom, args.max_zoom,
         args.jobs, args.grid, args.max_error, args.tile_px, args.force)
+    manifest['terrain'] = {
+        'path': 'terrain/layer.json',
+        'minZoom': args.min_zoom,
+        'maxZoom': args.max_zoom,
+        'tileCounts': {str(zoom): len(per_level[zoom]) for zoom in per_level},
+        'renderCounts': counts,
+    }
+    atomic_json(package_dir / 'region.json', manifest)
     metadata = {
         'dataset': manifest['dataset'],
         'elevationReference': manifest['elevationReference'],
-        'sourceManifest': 'sources.json',
+        'sourceManifest': '../region.json',
         'sourceCRS': [record['crs'] for record in source_records],
         'tileCounts': {str(zoom): len(per_level[zoom]) for zoom in per_level},
     }
     qmesh.write_layer_json(
-        out_dir, args.max_zoom, per_level, args.min_zoom,
+        terrain_dir, args.max_zoom, per_level, args.min_zoom,
         bounds=bbox, output_minzoom=args.min_zoom, metadata=metadata)
     incomplete.unlink(missing_ok=True)
-    print('complete: %s (%s)' % (out_dir, counts), flush=True)
+    print('complete: %s (%s)' % (package_dir, counts), flush=True)
 
 
 def parse_args(argv=None):

--- a/scripts/terrain/terrain_to_qmesh.py
+++ b/scripts/terrain/terrain_to_qmesh.py
@@ -46,6 +46,89 @@ def validate_bbox(bbox):
     return [float(value) for value in bbox]
 
 
+def lod_tile_set(z_fine, fx0, fx1, fy0, fy1, z_min, ring):
+    """Match Map3D's nested fine patch and coarser LOD rings."""
+    keys = set((z_fine, x, y)
+               for x in range(fx0, fx1 + 1)
+               for y in range(fy0, fy1 + 1))
+    hx0, hx1, hy0, hy1 = fx0, fx1, fy0, fy1
+    zoom = z_fine
+    while zoom - 1 >= z_min:
+        zoom -= 1
+        skip_x0, skip_x1 = (hx0 + 1) // 2, (hx1 - 1) // 2
+        skip_y0, skip_y1 = (hy0 + 1) // 2, (hy1 - 1) // 2
+        outer_x0, outer_x1 = hx0 // 2 - ring, hx1 // 2 + ring
+        outer_y0, outer_y1 = hy0 // 2 - ring, hy1 // 2 + ring
+        for x in range(outer_x0, outer_x1 + 1):
+            for y in range(outer_y0, outer_y1 + 1):
+                if skip_x0 <= x <= skip_x1 and skip_y0 <= y <= skip_y1:
+                    continue
+                keys.add((zoom, x, y))
+        hx0, hx1 = outer_x0, outer_x1
+        hy0, hy1 = outer_y0, outer_y1
+    return keys
+
+
+def build_lod_worklist(bbox, minzoom, maxzoom, fine_radius, ring,
+                       max_focus_tiles):
+    focus_x0, focus_x1, focus_y0, focus_y1 = qmesh.tile_range_for_bbox(
+        maxzoom, *bbox)
+    focus_count = ((focus_x1 - focus_x0 + 1) *
+                   (focus_y1 - focus_y0 + 1))
+    if focus_count > max_focus_tiles:
+        raise RuntimeError(
+            '%d focus tiles exceed --max-focus-tiles %d' %
+            (focus_count, max_focus_tiles))
+    keys = set()
+    for focus_x in range(focus_x0, focus_x1 + 1):
+        for focus_y in range(focus_y0, focus_y1 + 1):
+            keys.update(lod_tile_set(
+                maxzoom,
+                focus_x - fine_radius, focus_x + fine_radius,
+                focus_y - fine_radius, focus_y + fine_radius,
+                minzoom, ring))
+    normalized = set()
+    for zoom, x, y in keys:
+        limit = 1 << zoom
+        if 0 <= y < limit:
+            normalized.add((zoom, x % limit, y))
+    ordered = sorted(normalized)
+    per_level = {zoom: [] for zoom in range(minzoom, maxzoom + 1)}
+    packed = []
+    for zoom, x, y in ordered:
+        per_level[zoom].append((x, y))
+        packed.append(qmesh.pack_key(zoom, x, y))
+    return np.asarray(packed, dtype=np.int64), per_level, focus_count
+
+
+def worklist_bounds(keys):
+    west, south, east, north = 180.0, 90.0, -180.0, -90.0
+    for packed in keys:
+        zoom, x, y = qmesh._decode_key(packed)
+        tile_west, tile_south, tile_east, tile_north = qmesh.tile_bounds(
+            zoom, x, y)
+        west = min(west, tile_west)
+        south = min(south, tile_south)
+        east = max(east, tile_east)
+        north = max(north, tile_north)
+    return [west, south, east, north]
+
+
+def sampling_bounds(prepared_bounds, minzoom, grid):
+    """Add one sample of margin around the edge-aligned regular mesh read."""
+    if grid <= 1:
+        return list(prepared_bounds)
+    tiles = 1 << minzoom
+    lon_margin = 360.0 / tiles / (grid - 1)
+    lat_margin = 180.0 / tiles / (grid - 1)
+    return [
+        max(-180.0, prepared_bounds[0] - lon_margin),
+        max(-90.0, prepared_bounds[1] - lat_margin),
+        min(180.0, prepared_bounds[2] + lon_margin),
+        min(90.0, prepared_bounds[3] + lat_margin),
+    ]
+
+
 def product_key(product):
     match = TILE_NAME_RE.search(product.get('title', ''))
     if match:
@@ -250,9 +333,11 @@ def mosaic_valid_fraction(path, bbox):
 
 
 def render_tiles(source_path, out_dir, bbox, minzoom, maxzoom, jobs, grid,
-                 max_error, tile_px, force):
-    keys, _expected = qmesh.build_worklist_for_bbox(
-        bbox, minzoom, maxzoom, want_levels=False)
+                 max_error, tile_px, force, worklist=None):
+    keys = worklist
+    if keys is None:
+        keys, _expected = qmesh.build_worklist_for_bbox(
+            bbox, minzoom, maxzoom, want_levels=False)
     total = len(keys)
     if total == 0:
         raise RuntimeError('bbox produced no terrain tiles')
@@ -290,6 +375,10 @@ def prepare(args):
     bbox = validate_bbox(args.bbox)
     if args.min_zoom < 0 or args.max_zoom > 19 or args.min_zoom > args.max_zoom:
         raise ValueError('zoom range must satisfy 0 <= MIN <= MAX <= 19')
+    if args.fine_radius < 0 or args.lod_ring < 0:
+        raise ValueError('fine radius and LOD ring must be non-negative')
+    if args.max_focus_tiles < 1:
+        raise ValueError('max focus tiles must be positive')
 
     package_dir = Path(args.out).resolve()
     terrain_dir = package_dir / 'terrain'
@@ -316,10 +405,26 @@ def prepare(args):
         'sourceRasters': [],
     }
 
+    worklist, expected_tiles, focus_count = build_lod_worklist(
+        bbox, args.min_zoom, args.max_zoom, args.fine_radius,
+        args.lod_ring, args.max_focus_tiles)
+    prepared_bounds = worklist_bounds(worklist)
+    mosaic_bounds = sampling_bounds(prepared_bounds, args.min_zoom, args.grid)
+    manifest['preparedBounds'] = prepared_bounds
+    manifest['mosaicBounds'] = mosaic_bounds
+    manifest['lodPolicy'] = {
+        'fineRadius': args.fine_radius,
+        'ring': args.lod_ring,
+        'localHandoffZoom': args.min_zoom,
+        'focusTileCount': focus_count,
+        'expectedTileCounts': {
+            str(zoom): len(expected_tiles[zoom]) for zoom in expected_tiles},
+    }
+
     if args.usgs_1m:
-        products, query_url = query_usgs_products(bbox)
+        products, query_url = query_usgs_products(mosaic_bounds)
         if not products:
-            raise RuntimeError('USGS has no 1 m GeoTIFF products for this bbox')
+            raise RuntimeError('USGS has no 1 m GeoTIFF products for the prepared bounds')
         if len(products) > args.max_products:
             raise RuntimeError('%d USGS tiles exceed --max-products %d' %
                                (len(products), args.max_products))
@@ -340,27 +445,22 @@ def prepare(args):
             raise RuntimeError('source raster not found: %s' % source_path)
         source_paths = [source_path]
 
-    x0, x1, y0, y1 = qmesh.tile_range_for_bbox(args.max_zoom, *bbox)
-    first_bounds = qmesh.tile_bounds(args.max_zoom, x0, y0)
-    last_bounds = qmesh.tile_bounds(args.max_zoom, x1, y1)
-    mosaic_bounds = [first_bounds[0], first_bounds[1],
-                     last_bounds[2], last_bounds[3]]
-    manifest['preparedBounds'] = mosaic_bounds
     mosaic_path = package_dir / '_source.tif'
     source_records, mosaic_record = build_mosaic(
         source_paths, mosaic_path, mosaic_bounds)
     manifest['sourceRasters'] = source_records
     manifest['mosaic'] = mosaic_record
-    valid_fraction = mosaic_valid_fraction(mosaic_path, bbox)
-    manifest['mosaic']['requestedBoundsValidFraction'] = valid_fraction
+    valid_fraction = mosaic_valid_fraction(mosaic_path, prepared_bounds)
+    manifest['mosaic']['preparedBoundsValidFraction'] = valid_fraction
     if valid_fraction < 0.99:
         atomic_json(package_dir / 'region.json', manifest)
         raise RuntimeError(
-            'source data covers only %.1f%% of the requested bbox; choose a smaller '
+            'source data covers only %.1f%% of the prepared bounds; choose a smaller '
             'zone or another source raster' % (100.0 * valid_fraction))
     per_level, counts = render_tiles(
         mosaic_path, terrain_dir, bbox, args.min_zoom, args.max_zoom,
-        args.jobs, args.grid, args.max_error, args.tile_px, args.force)
+        args.jobs, args.grid, args.max_error, args.tile_px, args.force,
+        worklist=worklist)
     manifest['terrain'] = {
         'path': 'terrain/layer.json',
         'minZoom': args.min_zoom,
@@ -374,11 +474,13 @@ def prepare(args):
         'elevationReference': manifest['elevationReference'],
         'sourceManifest': '../region.json',
         'sourceCRS': [record['crs'] for record in source_records],
+        'localHandoffZoom': args.min_zoom,
+        'lodPolicy': manifest['lodPolicy'],
         'tileCounts': {str(zoom): len(per_level[zoom]) for zoom in per_level},
     }
     qmesh.write_layer_json(
         terrain_dir, args.max_zoom, per_level, args.min_zoom,
-        bounds=bbox, output_minzoom=args.min_zoom, metadata=metadata,
+        bounds=prepared_bounds, output_minzoom=args.min_zoom, metadata=metadata,
         merge_existing=False)
     incomplete.unlink(missing_ok=True)
     print('complete: %s (%s)' % (package_dir, counts), flush=True)
@@ -399,6 +501,12 @@ def parse_args(argv=None):
     parser.add_argument('--grid', type=int, default=65)
     parser.add_argument('--tile-px', type=int, default=256)
     parser.add_argument('--max-error', type=float, default=4.0)
+    parser.add_argument('--fine-radius', type=int, default=2,
+                        help='Map3D fine-tile radius around each focus tile')
+    parser.add_argument('--lod-ring', type=int, default=1,
+                        help='Map3D coarser-ring width')
+    parser.add_argument('--max-focus-tiles', type=int, default=100000,
+                        help='abort when the operational AOI has more focus tiles')
     parser.add_argument('--max-products', type=int, default=100,
                         help='abort before downloading more than this many USGS tiles')
     parser.add_argument('--elevation-reference', default='source values; no vertical conversion')

--- a/scripts/terrain/test_terrain_to_qmesh.py
+++ b/scripts/terrain/test_terrain_to_qmesh.py
@@ -99,13 +99,45 @@ def test_rejects_invalid_bbox_order():
         terrain.validate_bbox([-105.0, 40.0, -106.0, 41.0])
 
 
+def test_lod_worklist_matches_default_map3d_footprint():
+    bbox = [-105.2751, 39.9949, -105.2750, 39.9950]
+
+    keys, per_level, focus_count = terrain.build_lod_worklist(
+        bbox, 13, 18, fine_radius=2, ring=1, max_focus_tiles=100)
+
+    assert focus_count == 1
+    assert len(keys) == 130
+    assert [len(per_level[zoom]) for zoom in range(13, 19)] == [21, 21, 21, 21, 21, 25]
+    for zoom in (13, 18):
+        xs = [x for x, _y in per_level[zoom]]
+        ys = [y for _x, y in per_level[zoom]]
+        assert max(xs) - min(xs) + 1 == 5
+        assert max(ys) - min(ys) + 1 == 5
+
+
+def test_lod_worklist_does_not_fill_coarse_bounds_at_fine_zoom():
+    bbox = list(qmesh.tile_bounds(18, 108825, 189318))
+    bbox[2] = qmesh.tile_bounds(18, 108826, 189318)[2]
+
+    keys, per_level, _focus_count = terrain.build_lod_worklist(
+        bbox, 13, 18, fine_radius=2, ring=1, max_focus_tiles=100)
+    prepared = terrain.worklist_bounds(keys)
+    x0, x1, y0, y1 = qmesh.tile_range_for_bbox(18, *prepared)
+    full_rectangle_count = (x1 - x0 + 1) * (y1 - y0 + 1)
+
+    assert len(per_level[18]) < full_rectangle_count // 100
+
+
 def test_local_raster_build_publishes_regional_package(tmp_path):
     source = tmp_path / 'source.tif'
     bbox = [-105.001, 39.999, -104.999, 40.001]
+    x0, _x1, y0, _y1 = qmesh.tile_range_for_bbox(13, *bbox)
+    source_bounds = terrain.sampling_bounds(
+        qmesh.tile_bounds(13, x0, y0), 13, 65)
     with rasterio.open(
             source, 'w', driver='GTiff', width=256, height=256, count=1,
             dtype='float32', crs='EPSG:4326', nodata=-32768.0,
-            transform=from_bounds(*bbox, 256, 256)) as dataset:
+            transform=from_bounds(*source_bounds, 256, 256)) as dataset:
         dataset.write(np.full((256, 256), 1234.5, dtype=np.float32), 1)
     package = tmp_path / 'package'
     args = terrain.parse_args([
@@ -113,6 +145,7 @@ def test_local_raster_build_publishes_regional_package(tmp_path):
         '--bbox', *(str(value) for value in bbox),
         '--min-zoom', '13', '--max-zoom', '13',
         '--out', str(package), '--jobs', '1',
+        '--fine-radius', '0', '--lod-ring', '0',
     ])
 
     terrain.prepare(args)
@@ -121,6 +154,8 @@ def test_local_raster_build_publishes_regional_package(tmp_path):
     assert region['schemaVersion'] == 1
     assert region['terrain']['path'] == 'terrain/layer.json'
     assert region['terrain']['renderCounts']['ok'] == 1
+    assert region['lodPolicy']['fineRadius'] == 0
+    assert region['lodPolicy']['localHandoffZoom'] == 13
     assert (package / 'terrain' / 'layer.json').is_file()
     assert len(list((package / 'terrain' / '13').glob('*/*.terrain'))) == 1
     assert not (package / '.incomplete').exists()

--- a/scripts/terrain/test_terrain_to_qmesh.py
+++ b/scripts/terrain/test_terrain_to_qmesh.py
@@ -50,6 +50,23 @@ def test_layer_json_records_regional_contract(tmp_path):
     assert layer['available'][18]
 
 
+def test_regional_layer_does_not_merge_stale_availability(tmp_path):
+    qmesh.write_layer_json(
+        str(tmp_path), 18, {18: [(10, 20)]}, 18,
+        bounds=[1.0, 2.0, 3.0, 4.0], output_minzoom=18,
+        merge_existing=False)
+    qmesh.write_layer_json(
+        str(tmp_path), 18, {18: [(30, 40)]}, 18,
+        bounds=[5.0, 6.0, 7.0, 8.0], output_minzoom=18,
+        merge_existing=False)
+
+    layer = json.loads((tmp_path / 'layer.json').read_text())
+
+    assert layer['bounds'] == [5.0, 6.0, 7.0, 8.0]
+    assert layer['available'][18] == [
+        {'startX': 30, 'startY': 40, 'endX': 30, 'endY': 40}]
+
+
 def test_latest_product_is_selected_for_each_usgs_tile():
     products = [
         _product('old x47y443', '2022-02-10', 'https://example/old.tif', 10),

--- a/scripts/terrain/test_terrain_to_qmesh.py
+++ b/scripts/terrain/test_terrain_to_qmesh.py
@@ -1,4 +1,5 @@
 import gzip
+import io
 import json
 import struct
 import sys
@@ -14,6 +15,12 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 import srtm_to_qmesh as qmesh
 import terrain_to_qmesh as terrain
+
+
+class FakeResponse(io.BytesIO):
+    def __init__(self, payload, headers):
+        super().__init__(payload)
+        self.headers = headers
 
 
 def test_bbox_worklist_contains_only_intersecting_tiles():
@@ -94,6 +101,75 @@ def test_product_selection_falls_back_when_newest_has_no_data():
         products, probe=lambda product: 'old.tif' in product['downloadURL'])
 
     assert [item['downloadURL'] for item in selected] == ['https://example/old.tif']
+
+
+def test_download_accepts_live_size_and_records_stale_catalog_size(tmp_path, monkeypatch):
+    payload = b'complete live object'
+    product = _product(
+        'one meter x28y383', '2026-03-20',
+        'https://example/terrain.tif', len(payload) - 2)
+
+    def fake_urlopen(request, timeout):
+        assert request.get_method() == 'GET'
+        assert timeout == 120
+        return FakeResponse(payload, {
+            'Content-Length': str(len(payload)),
+            'Content-Type': 'image/tiff',
+            'ETag': '"live-etag"',
+            'Last-Modified': 'Sun, 09 Aug 2026 18:46:10 GMT',
+        })
+
+    monkeypatch.setattr(terrain, 'urlopen', fake_urlopen)
+    path, record = terrain.download_product(product, tmp_path)
+
+    assert path.read_bytes() == payload
+    assert record['downloadedBytes'] == len(payload)
+    assert record['catalogLiveSizeDiscrepancyBytes'] == 2
+    assert record['httpIdentity'] == {
+        'contentLength': len(payload),
+        'contentType': 'image/tiff',
+        'etag': '"live-etag"',
+        'lastModified': 'Sun, 09 Aug 2026 18:46:10 GMT',
+    }
+
+
+def test_download_reuses_live_sized_file_when_catalog_size_is_stale(tmp_path, monkeypatch):
+    payload = b'previous complete live object'
+    product = _product(
+        'one meter x28y383', '2026-03-20',
+        'https://example/terrain.tif', len(payload) - 2)
+    (tmp_path / 'terrain.tif').write_bytes(payload)
+
+    def fake_urlopen(request, timeout):
+        assert request.get_method() == 'HEAD'
+        assert timeout == 60
+        return FakeResponse(b'', {'Content-Length': str(len(payload))})
+
+    monkeypatch.setattr(terrain, 'urlopen', fake_urlopen)
+    path, record = terrain.download_product(product, tmp_path)
+
+    assert path.read_bytes() == payload
+    assert record['downloadedBytes'] == len(payload)
+    assert record['catalogLiveSizeDiscrepancyBytes'] == 2
+    assert record['httpIdentity']['contentLength'] == len(payload)
+
+
+def test_download_rejects_incomplete_live_transfer(tmp_path, monkeypatch):
+    payload = b'incomplete'
+    product = _product(
+        'one meter x28y383', '2026-03-20',
+        'https://example/terrain.tif', len(payload))
+
+    def fake_urlopen(_request, timeout):
+        assert timeout == 120
+        return FakeResponse(payload, {'Content-Length': str(len(payload) + 1)})
+
+    monkeypatch.setattr(terrain, 'urlopen', fake_urlopen)
+
+    with pytest.raises(RuntimeError, match='download size mismatch'):
+        terrain.download_product(product, tmp_path)
+    assert not (tmp_path / 'terrain.tif').exists()
+    assert not (tmp_path / 'terrain.tif.part').exists()
 
 
 def test_rejects_invalid_bbox_order():

--- a/scripts/terrain/test_terrain_to_qmesh.py
+++ b/scripts/terrain/test_terrain_to_qmesh.py
@@ -1,0 +1,94 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import srtm_to_qmesh as qmesh
+import terrain_to_qmesh as terrain
+
+
+def test_bbox_worklist_contains_only_intersecting_tiles():
+    bbox = [149.0000, -35.9995, 149.0010, -35.9985]
+    keys, per_level = qmesh.build_worklist_for_bbox(bbox, 17, 18)
+
+    assert len(keys) > 0
+    assert set(per_level) == {17, 18}
+    for packed in keys:
+        z, x, y = qmesh._decode_key(packed)
+        west, south, east, north = qmesh.tile_bounds(z, x, y)
+        assert west < bbox[2]
+        assert east > bbox[0]
+        assert south < bbox[3]
+        assert north > bbox[1]
+
+
+def test_layer_json_records_regional_contract(tmp_path):
+    bbox = [-105.276, 39.994, -105.274, 39.996]
+    _, per_level = qmesh.build_worklist_for_bbox(bbox, 17, 18)
+    metadata = {
+        'dataset': 'Digital Elevation Model (DEM) 1 meter',
+        'elevationReference': 'NAVD88 as supplied by USGS',
+    }
+
+    qmesh.write_layer_json(
+        tmp_path, 18, per_level, 17, bounds=bbox,
+        output_minzoom=17, metadata=metadata)
+
+    layer = json.loads((tmp_path / 'layer.json').read_text())
+    assert layer['bounds'] == bbox
+    assert layer['minzoom'] == 17
+    assert layer['maxzoom'] == 18
+    assert layer['metadata'] == metadata
+    assert layer['available'][17]
+    assert layer['available'][18]
+
+
+def test_latest_product_is_selected_for_each_usgs_tile():
+    products = [
+        _product('old x47y443', '2022-02-10', 'https://example/old.tif', 10),
+        _product('new x47y443', '2026-03-20', 'https://example/new.tif', 11),
+        _product('only x48y443', '2024-01-01', 'https://example/other.tif', 12),
+    ]
+
+    selected = terrain.select_current_products(products)
+
+    assert [item['downloadURL'] for item in selected] == [
+        'https://example/new.tif',
+        'https://example/other.tif',
+    ]
+
+
+def test_product_selection_falls_back_when_newest_has_no_data():
+    products = [
+        _product('old x47y443', '2022-02-10', 'https://example/old.tif', 10),
+        _product('new x47y443', '2026-03-20', 'https://example/new.tif', 11),
+    ]
+
+    selected = terrain.select_current_products(
+        products, probe=lambda product: 'old.tif' in product['downloadURL'])
+
+    assert [item['downloadURL'] for item in selected] == ['https://example/old.tif']
+
+
+def test_rejects_invalid_bbox_order():
+    with pytest.raises(ValueError, match='WEST < EAST'):
+        terrain.validate_bbox([-105.0, 40.0, -106.0, 41.0])
+
+
+def _product(title, publication_date, url, size):
+    return {
+        'title': title,
+        'publicationDate': publication_date,
+        'downloadURL': url,
+        'sizeInBytes': size,
+        'boundingBox': {
+            'minX': -105.4,
+            'minY': 39.9,
+            'maxX': -105.2,
+            'maxY': 40.1,
+        },
+    }

--- a/scripts/terrain/test_terrain_to_qmesh.py
+++ b/scripts/terrain/test_terrain_to_qmesh.py
@@ -1,4 +1,6 @@
+import gzip
 import json
+import struct
 import sys
 from pathlib import Path
 
@@ -128,7 +130,8 @@ def test_lod_worklist_does_not_fill_coarse_bounds_at_fine_zoom():
     assert len(per_level[18]) < full_rectangle_count // 100
 
 
-def test_local_raster_build_publishes_regional_package(tmp_path):
+@pytest.mark.parametrize('height', [1234.5, -1200.25])
+def test_local_raster_build_preserves_valid_heights(tmp_path, height):
     source = tmp_path / 'source.tif'
     bbox = [-105.001, 39.999, -104.999, 40.001]
     x0, _x1, y0, _y1 = qmesh.tile_range_for_bbox(13, *bbox)
@@ -138,7 +141,7 @@ def test_local_raster_build_publishes_regional_package(tmp_path):
             source, 'w', driver='GTiff', width=256, height=256, count=1,
             dtype='float32', crs='EPSG:4326', nodata=-32768.0,
             transform=from_bounds(*source_bounds, 256, 256)) as dataset:
-        dataset.write(np.full((256, 256), 1234.5, dtype=np.float32), 1)
+        dataset.write(np.full((256, 256), height, dtype=np.float32), 1)
     package = tmp_path / 'package'
     args = terrain.parse_args([
         '--source-raster', str(source),
@@ -157,8 +160,33 @@ def test_local_raster_build_publishes_regional_package(tmp_path):
     assert region['lodPolicy']['fineRadius'] == 0
     assert region['lodPolicy']['localHandoffZoom'] == 13
     assert (package / 'terrain' / 'layer.json').is_file()
-    assert len(list((package / 'terrain' / '13').glob('*/*.terrain'))) == 1
+    terrain_files = list((package / 'terrain' / '13').glob('*/*.terrain'))
+    assert len(terrain_files) == 1
+    payload = gzip.decompress(terrain_files[0].read_bytes())
+    minimum, maximum = struct.unpack_from('<ff', payload, 24)
+    assert minimum == pytest.approx(height, abs=0.01)
+    assert maximum == pytest.approx(height, abs=0.01)
     assert not (package / '.incomplete').exists()
+
+
+def test_local_raster_rejects_uncovered_emitted_tile(tmp_path):
+    source = tmp_path / 'source.tif'
+    bbox = [-105.001, 39.999, -104.999, 40.001]
+    with rasterio.open(
+            source, 'w', driver='GTiff', width=100, height=100, count=1,
+            dtype='float32', crs='EPSG:4326', nodata=-32768.0,
+            transform=from_bounds(*bbox, 100, 100)) as dataset:
+        dataset.write(np.full((100, 100), 1234.0, dtype=np.float32), 1)
+    args = terrain.parse_args([
+        '--source-raster', str(source),
+        '--bbox', *(str(value) for value in bbox),
+        '--min-zoom', '13', '--max-zoom', '13',
+        '--out', str(tmp_path / 'package'), '--jobs', '1',
+        '--fine-radius', '0', '--lod-ring', '0',
+    ])
+
+    with pytest.raises(RuntimeError, match='covers only .* prepared bounds'):
+        terrain.prepare(args)
 
 
 def _product(title, publication_date, url, size):

--- a/scripts/terrain/test_terrain_to_qmesh.py
+++ b/scripts/terrain/test_terrain_to_qmesh.py
@@ -2,7 +2,10 @@ import json
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
+import rasterio
+from rasterio.transform import from_bounds
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
@@ -77,6 +80,33 @@ def test_product_selection_falls_back_when_newest_has_no_data():
 def test_rejects_invalid_bbox_order():
     with pytest.raises(ValueError, match='WEST < EAST'):
         terrain.validate_bbox([-105.0, 40.0, -106.0, 41.0])
+
+
+def test_local_raster_build_publishes_regional_package(tmp_path):
+    source = tmp_path / 'source.tif'
+    bbox = [-105.001, 39.999, -104.999, 40.001]
+    with rasterio.open(
+            source, 'w', driver='GTiff', width=256, height=256, count=1,
+            dtype='float32', crs='EPSG:4326', nodata=-32768.0,
+            transform=from_bounds(*bbox, 256, 256)) as dataset:
+        dataset.write(np.full((256, 256), 1234.5, dtype=np.float32), 1)
+    package = tmp_path / 'package'
+    args = terrain.parse_args([
+        '--source-raster', str(source),
+        '--bbox', *(str(value) for value in bbox),
+        '--min-zoom', '13', '--max-zoom', '13',
+        '--out', str(package), '--jobs', '1',
+    ])
+
+    terrain.prepare(args)
+
+    region = json.loads((package / 'region.json').read_text())
+    assert region['schemaVersion'] == 1
+    assert region['terrain']['path'] == 'terrain/layer.json'
+    assert region['terrain']['renderCounts']['ok'] == 1
+    assert (package / 'terrain' / 'layer.json').is_file()
+    assert len(list((package / 'terrain' / '13').glob('*/*.terrain'))) == 1
+    assert not (package / '.incomplete').exists()
 
 
 def _product(title, publication_date, url, size):


### PR DESCRIPTION
## Summary
- add a bounded internal USGS 3DEP 1 m / local-raster preparation CLI
- preserve the existing SRTM converter and shared quantized-mesh encoder
- publish `region.json` plus truthful fresh `terrain/layer.json` availability
- derive sparse per-level coverage from Map3D fine-radius/ring LOD behavior
- record source URLs, checksums, CRS, elevation reference, nodata policy, and build metadata

## Verification
- `9 passed` in `scripts/terrain/test_terrain_to_qmesh.py`
- real TNM selection rejected newer no-data products and selected four complete 2022 CO DRCOG tiles
- built and decoded 130/130 zoom 13-18 terrain tiles; heights were finite (1584.88-2592.66 m)
- all 180 adjacent same-level edges were within 0.022 m
- the real package loaded through MAVProxy Map3D with all expected local LOD levels

This is a draft while the paired MAVProxy runtime change completes final vehicle/replay edge acceptance.
